### PR TITLE
consumer close() fixes + multi-topic consumer subscriptions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/google/uuid v1.1.2
 	github.com/grpc-ecosystem/go-grpc-middleware v1.0.0
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
+	github.com/grpc-ecosystem/grpc-gateway v1.9.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.0.1
 	github.com/hashicorp/consul/api v1.8.1
 	github.com/hashicorp/go-hclog v0.15.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -274,6 +274,7 @@ github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92Bcuy
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0 h1:bM6ZAFZmc/wPFaRDi0d5L7hGEZEx/2u+Tmr2evNHDiI=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
+github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4M0+kPpLofRdBo=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.0.1 h1:X2vfSnm1WC8HEo0MBHZg2TcuDUHJj6kd1TmEAQncnSA=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.0.1/go.mod h1:oVMjMN64nzEcepv1kdZKgx1qNYt4Ro0Gqefiq2JWdis=
 github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c h1:6rhixN/i8ZofjG1Y75iExal34USq5p+wiN1tpie8IrU=

--- a/internal/brokerstore/brokerstore.go
+++ b/internal/brokerstore/brokerstore.go
@@ -61,7 +61,7 @@ type IBrokerStore interface {
 	GetConsumer(ctx context.Context, id string, op messagebroker.ConsumerClientOptions) (messagebroker.Consumer, error)
 
 	// RemoveConsumer deletes the consumer from the store
-	RemoveConsumer(ctx context.Context, id string, op messagebroker.ConsumerClientOptions)
+	RemoveConsumer(ctx context.Context, id string, op messagebroker.ConsumerClientOptions) bool
 
 	// GetProducer returns for an existing producer instance, if available returns that else creates as new instance
 	GetProducer(ctx context.Context, op messagebroker.ProducerClientOptions) (messagebroker.Producer, error)
@@ -115,9 +115,10 @@ func (b *BrokerStore) GetConsumer(ctx context.Context, id string, op messagebrok
 }
 
 // RemoveConsumer deletes the consumer from the store
-func (b *BrokerStore) RemoveConsumer(_ context.Context, id string, op messagebroker.ConsumerClientOptions) {
+func (b *BrokerStore) RemoveConsumer(_ context.Context, id string, op messagebroker.ConsumerClientOptions) bool {
 	key := NewKey(op.GroupID, id)
-	b.consumerMap.LoadAndDelete(key)
+	_, loaded := b.consumerMap.LoadAndDelete(key)
+	return loaded
 }
 
 // GetProducer returns for an existing producer instance, if available returns that else creates as new instance

--- a/internal/brokerstore/brokerstore.go
+++ b/internal/brokerstore/brokerstore.go
@@ -60,6 +60,9 @@ type IBrokerStore interface {
 	// GetConsumer returns for an existing consumer instance, if available returns that else creates as new instance
 	GetConsumer(ctx context.Context, id string, op messagebroker.ConsumerClientOptions) (messagebroker.Consumer, error)
 
+	// RemoveConsumer deletes the consumer from the store
+	RemoveConsumer(ctx context.Context, id string, op messagebroker.ConsumerClientOptions)
+
 	// GetProducer returns for an existing producer instance, if available returns that else creates as new instance
 	GetProducer(ctx context.Context, op messagebroker.ProducerClientOptions) (messagebroker.Producer, error)
 
@@ -109,6 +112,12 @@ func (b *BrokerStore) GetConsumer(ctx context.Context, id string, op messagebrok
 	consumer, _ = b.consumerMap.LoadOrStore(key.String(), newConsumer)
 	b.partitionLock.Unlock(key.String()) // unlock
 	return consumer.(messagebroker.Consumer), nil
+}
+
+// RemoveConsumer deletes the consumer from the store
+func (b *BrokerStore) RemoveConsumer(_ context.Context, id string, op messagebroker.ConsumerClientOptions) {
+	key := NewKey(op.GroupID, id)
+	b.consumerMap.LoadAndDelete(key)
 }
 
 // GetProducer returns for an existing producer instance, if available returns that else creates as new instance

--- a/pkg/messagebroker/config.go
+++ b/pkg/messagebroker/config.go
@@ -46,7 +46,7 @@ type AdminConfig struct{}
 
 // ConsumerClientOptions holds client specific configuration for consumer
 type ConsumerClientOptions struct {
-	Topic        string
+	Topics       []string
 	Subscription string
 	GroupID      string
 	Partition    int

--- a/pkg/messagebroker/kafka.go
+++ b/pkg/messagebroker/kafka.go
@@ -70,7 +70,7 @@ func newKafkaConsumerClient(ctx context.Context, bConfig *BrokerConfig, id strin
 		return nil, err
 	}
 
-	c.SubscribeTopics([]string{options.Topic}, nil)
+	c.SubscribeTopics(options.Topics, nil)
 
 	return &KafkaBroker{
 		Consumer: c,
@@ -326,6 +326,7 @@ func (k *KafkaBroker) SendMessage(ctx context.Context, request SendMessageToTopi
 //from the previous committed offset. If the available messages in the queue are less, returns
 // how many ever messages are available
 func (k *KafkaBroker) ReceiveMessages(ctx context.Context, request GetMessagesFromTopicRequest) (*GetMessagesFromTopicResponse, error) {
+
 	msgs := make(map[string]ReceivedMessage, 0)
 	for {
 		var msgID string
@@ -420,19 +421,19 @@ func (k *KafkaBroker) Resume(_ context.Context, request ResumeOnTopicRequest) er
 
 // Close closes the consumer
 func (k *KafkaBroker) Close(ctx context.Context) error {
-	logger.Ctx(ctx).Infow("kafka: request to close the consumer", "topic", k.COptions.Topic, "groupID", k.COptions.GroupID)
+	logger.Ctx(ctx).Infow("kafka: request to close the consumer", "topic", k.COptions.Topics, "groupID", k.COptions.GroupID)
 	err := k.Consumer.Unsubscribe()
 	if err != nil {
-		logger.Ctx(ctx).Errorw("kafka: consumer unsubscribe failed", "topic", k.COptions.Topic, "groupID", k.COptions.GroupID, "error", err.Error())
+		logger.Ctx(ctx).Errorw("kafka: consumer unsubscribe failed", "topic", k.COptions.Topics, "groupID", k.COptions.GroupID, "error", err.Error())
 		return err
 	}
 
 	err = k.Consumer.Close()
 	if err != nil {
-		logger.Ctx(ctx).Errorw("kafka: consumer close failed", "topic", k.COptions.Topic, "groupID", k.COptions.GroupID, "error", err.Error())
+		logger.Ctx(ctx).Errorw("kafka: consumer close failed", "topic", k.COptions.Topics, "groupID", k.COptions.GroupID, "error", err.Error())
 		return err
 	}
-	logger.Ctx(ctx).Infow("kafka: consumer closed...", "topic", k.COptions.Topic, "groupID", k.COptions.GroupID)
+	logger.Ctx(ctx).Infow("kafka: consumer closed...", "topic", k.COptions.Topics, "groupID", k.COptions.GroupID)
 
 	return nil
 }

--- a/pkg/messagebroker/kafka.go
+++ b/pkg/messagebroker/kafka.go
@@ -428,10 +428,10 @@ func (k *KafkaBroker) Close(ctx context.Context) error {
 		return err
 	}
 
-	err = k.Consumer.Close()
-	if err != nil {
-		logger.Ctx(ctx).Errorw("kafka: consumer close failed", "topic", k.COptions.Topics, "groupID", k.COptions.GroupID, "error", err.Error())
-		return err
+	cerr := k.Consumer.Close()
+	if cerr != nil {
+		logger.Ctx(ctx).Errorw("kafka: consumer close failed", "topic", k.COptions.Topics, "groupID", k.COptions.GroupID, "error", cerr.Error())
+		return cerr
 	}
 	logger.Ctx(ctx).Infow("kafka: consumer closed...", "topic", k.COptions.Topics, "groupID", k.COptions.GroupID)
 

--- a/pkg/messagebroker/pulsar.go
+++ b/pkg/messagebroker/pulsar.go
@@ -52,7 +52,7 @@ func newPulsarConsumerClient(ctx context.Context, bConfig *BrokerConfig, id stri
 	}
 
 	c, err := client.Subscribe(pulsar.ConsumerOptions{
-		Topic:            options.Topic,
+		Topics:           options.Topics,
 		SubscriptionName: options.Subscription,
 		Type:             pulsar.SubscriptionType(bConfig.Consumer.SubscriptionType),
 		Name:             id,

--- a/pkg/messagebroker/validations.go
+++ b/pkg/messagebroker/validations.go
@@ -7,7 +7,7 @@ import (
 // validateKafkaConsumerClientConfig validates kafka consumer client config
 func validateKafkaConsumerClientConfig(options *ConsumerClientOptions) error {
 
-	if options.Topic == "" {
+	if options.Topics == nil || len(options.Topics) == 0 {
 		return fmt.Errorf("kafka: empty topic name")
 	}
 

--- a/pkg/messagebroker/validations_test.go
+++ b/pkg/messagebroker/validations_test.go
@@ -8,7 +8,7 @@ import (
 
 func Test_validateKafkaConsumerClientConfig(t *testing.T) {
 	op1 := ConsumerClientOptions{
-		Topic:   "t1",
+		Topics:  []string{"t1"},
 		GroupID: "g1",
 	}
 
@@ -16,10 +16,10 @@ func Test_validateKafkaConsumerClientConfig(t *testing.T) {
 
 	ops := []ConsumerClientOptions{
 		{
-			Topic:   "t2",
+			Topics:  nil,
 			GroupID: "",
 		}, {
-			Topic:   "",
+			Topics:  []string{},
 			GroupID: "g3",
 		},
 	}

--- a/service/web/stream/stream.go
+++ b/service/web/stream/stream.go
@@ -131,6 +131,7 @@ func (s *pullStream) receive() {
 	req, err := s.server.Recv()
 	if err != nil {
 		s.errChan <- err
+		return
 	}
 	s.reqChan <- req
 }

--- a/tests/integration/messagebroker/messagebroker_kafka_test.go
+++ b/tests/integration/messagebroker/messagebroker_kafka_test.go
@@ -33,7 +33,7 @@ func Test_CreateValidTopic(t *testing.T) {
 
 	// create consumer to fetch topic metadata
 	consumer1, err := messagebroker.NewConsumerClient(context.Background(), "kafka", "id-1", getKafkaBrokerConfig(), &messagebroker.ConsumerClientOptions{
-		Topic:   topic,
+		Topics:  []string{topic},
 		GroupID: "dummy-group-2",
 	})
 	metadata, merr := consumer1.GetTopicMetadata(context.Background(), messagebroker.GetTopicMetadataRequest{Topic: topic})
@@ -149,7 +149,7 @@ func Test_ProduceAndConsumeMessagesInDetail(t *testing.T) {
 
 	// now consume the messages and assert the message ids generated in the previous step
 	consumer1, err := messagebroker.NewConsumerClient(context.Background(), "kafka", "id-1", getKafkaBrokerConfig(), &messagebroker.ConsumerClientOptions{
-		Topic:   topic,
+		Topics:  []string{topic},
 		GroupID: "dummy-group-1",
 	})
 
@@ -174,7 +174,7 @@ func Test_ProduceAndConsumeMessagesInDetail(t *testing.T) {
 
 	// spwan a new consumer and try to re-receive after commit and make sure no new messages are available
 	consumer3, err := messagebroker.NewConsumerClient(context.Background(), "kafka", "id-2", getKafkaBrokerConfig(), &messagebroker.ConsumerClientOptions{
-		Topic:   topic,
+		Topics:  []string{topic},
 		GroupID: "dummy-group-1",
 	})
 


### PR DESCRIPTION
- multi-topic subscription for the `consumer: primary+retry topic`. Tested locally. Works fine. Messages are being read from both topics.
- delete consumer from `brokerStore` after `Close()` is called

- Fixed panic on calling consumer `close()`.  **Scenario explained:** Two subscribers were sharing the same consumer. On `ctx.Done()` both were trying to close the consumer. One succeeded whereas the other `panic`'d saying the consumer is already closed. **Solution:** Made the `close()` conditional based on the `brokerStore`. Only the `subscriber` which successfully deletes from `brokerStore` will call the consumer `close()`.