### PR TITLE
proxy request incase of originating server address mismatch

### DIFF
--- a/service/web/service.go
+++ b/service/web/service.go
@@ -72,7 +72,7 @@ func (svc *Service) Start() error {
 
 	publisher := publisher.NewCore(brokerStore)
 
-	streamManager := stream.NewStreamManager(svc.ctx, subscriptionCore, brokerStore)
+	streamManager := stream.NewStreamManager(svc.ctx, subscriptionCore, brokerStore, svc.webConfig.Interfaces.API.GrpcServerAddress)
 
 	grpcServer, err := server.StartGRPCServer(
 		grp,

--- a/service/web/stream/manager.go
+++ b/service/web/stream/manager.go
@@ -180,6 +180,9 @@ func (s *Manager) ModifyAcknowledgement(ctx context.Context, parsedReq *ParsedSt
 // proxy request to the specified server
 func (pr *proxyRequest) do(ctx context.Context) {
 
+	// from config grpcServerAddr would be read as => 0.0.0.0:8081
+	// we extract the port(8081) out of the host+grpc_port string and append it to the ack_msg_addr
+	// all proxy grpc calls would be made on this ack_msg_addr:grpc_port destination.
 	grpcPort := strings.Split(pr.grpcServerAddr, ":")[1]
 	destinationHostWithPort := fmt.Sprintf("%v:%v", pr.addr, grpcPort)
 

--- a/service/web/stream/manager.go
+++ b/service/web/stream/manager.go
@@ -133,7 +133,7 @@ func (s *Manager) Acknowledge(ctx context.Context, parsedReq *ParsedStreamingPul
 	if len(msgsToBeProxied) > 0 {
 		// proxy request to the correct server
 		for proxyAddr, ackMsgs := range msgsToBeProxied {
-			newProxyRequest(proxyAddr, ackMsgs, parsedReq, ack).do(ctx)
+			newAckProxyRequest(proxyAddr, ackMsgs, parsedReq).do(ctx)
 		}
 	}
 	return nil
@@ -167,7 +167,7 @@ func (s *Manager) ModifyAcknowledgement(ctx context.Context, parsedReq *ParsedSt
 	if len(msgsToBeProxied) > 0 {
 		// proxy request to the correct server
 		for proxyAddr, ackMsgs := range msgsToBeProxied {
-			newProxyRequest(proxyAddr, ackMsgs, parsedReq, modAck).do(ctx)
+			newModAckProxyRequest(proxyAddr, ackMsgs, parsedReq).do(ctx)
 		}
 	}
 	return nil

--- a/service/web/stream/manager.go
+++ b/service/web/stream/manager.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"sync"
 
+	"google.golang.org/grpc"
+
 	"github.com/razorpay/metro/pkg/logger"
 
 	"github.com/razorpay/metro/internal/brokerstore"
@@ -16,7 +18,7 @@ import (
 // IManager ...
 type IManager interface {
 	CreateNewStream(server metrov1.Subscriber_StreamingPullServer, req *ParsedStreamingPullRequest, errGroup *errgroup.Group) error
-	Acknowledge(ctx context.Context, req *ParsedStreamingPullRequest) error
+	Acknowledge(ctx context.Context, parsedReq *ParsedStreamingPullRequest) error
 	ModifyAcknowledgement(ctx context.Context, req *ParsedStreamingPullRequest) error
 }
 
@@ -107,23 +109,69 @@ func (s *Manager) CreateNewStream(server metrov1.Subscriber_StreamingPullServer,
 }
 
 // Acknowledge ...
-func (s *Manager) Acknowledge(ctx context.Context, req *ParsedStreamingPullRequest) error {
-	for _, ackMsg := range req.AckMessages {
+func (s *Manager) Acknowledge(ctx context.Context, parsedReq *ParsedStreamingPullRequest) error {
+
+	// holds a map of ackMsgs to their corresponding originating server addresses
+	msgsToBeProxied := make(map[string][]*subscriber.AckMessage, 0)
+
+	for _, ackMsg := range parsedReq.AckMessages {
 		if ackMsg.MatchesOriginatingMessageServer() {
 			// find active stream
 			if pullStream, ok := s.pullStreams[ackMsg.SubscriberID]; ok {
 				pullStream.acknowledge(ctx, ackMsg)
 			}
 		} else {
-			// proxy request to the correct server
+			proxyAddr := ackMsg.ServerAddress
+			if _, ok := msgsToBeProxied[proxyAddr]; !ok {
+				// init empty slice
+				msgsToBeProxied[proxyAddr] = make([]*subscriber.AckMessage, 0)
+			}
+			msgsToBeProxied[proxyAddr] = append(msgsToBeProxied[proxyAddr], ackMsg)
 		}
 	}
 
+	if len(msgsToBeProxied) > 0 {
+		// proxy request to the correct server
+		for proxyAddr, ackMsgs := range msgsToBeProxied {
+			conn, err := grpc.Dial(proxyAddr, []grpc.DialOption{grpc.WithInsecure()}...)
+			if err != nil {
+				return err
+			}
+
+			ackIds := collectAckIds(ackMsgs)
+			logger.Ctx(ctx).Infow("manager: acknowledge proxy request", "proxyAddr", proxyAddr, "ackIds", ackIds)
+
+			proxyAckRequest := &metrov1.AcknowledgeRequest{
+				Subscription: parsedReq.Subscription,
+				AckIds:       ackIds,
+			}
+			client := metrov1.NewSubscriberClient(conn)
+			_, aerr := client.Acknowledge(ctx, proxyAckRequest)
+			if aerr != nil {
+				logger.Ctx(ctx).Errorw("manager: acknowledge proxy request failed", "proxyAddr", proxyAddr, "error", aerr.Error())
+				// on error, try to proxy remaining requests
+				continue
+			}
+			logger.Ctx(ctx).Infow("manager: acknowledge proxy request succeeded", "proxyAddr", proxyAddr, "ackIds", ackIds)
+		}
+	}
 	return nil
+}
+
+func collectAckIds(msgs []*subscriber.AckMessage) []string {
+	ackIds := make([]string, 0)
+
+	for _, msg := range msgs {
+		ackIds = append(ackIds, msg.AckID)
+	}
+	return ackIds
 }
 
 // ModifyAcknowledgement ...
 func (s *Manager) ModifyAcknowledgement(ctx context.Context, req *ParsedStreamingPullRequest) error {
+	// holds a map of modAckMsgs to their corresponding originating server addresses
+	msgsToBeProxied := make(map[string][]*subscriber.AckMessage, 0)
+
 	for _, ackMsg := range req.AckMessages {
 		// non zero ack deadline is not supported, hence continue
 		if req.ModifyDeadlineMsgIdsWithSecs[ackMsg.MessageID] != 0 {
@@ -135,10 +183,43 @@ func (s *Manager) ModifyAcknowledgement(ctx context.Context, req *ParsedStreamin
 				pullStream.modifyAckDeadline(ctx, subscriber.NewModAckMessage(ackMsg, req.ModifyDeadlineMsgIdsWithSecs[ackMsg.MessageID]))
 			}
 		} else {
-			// proxy request to the correct server
+			proxyAddr := ackMsg.ServerAddress
+			if _, ok := msgsToBeProxied[proxyAddr]; !ok {
+				// init empty slice
+				msgsToBeProxied[proxyAddr] = make([]*subscriber.AckMessage, 0)
+			}
+			msgsToBeProxied[proxyAddr] = append(msgsToBeProxied[proxyAddr], ackMsg)
 		}
 	}
 
+	if len(msgsToBeProxied) > 0 {
+		// proxy request to the correct server
+		for proxyAddr, ackMsgs := range msgsToBeProxied {
+			conn, err := grpc.Dial(proxyAddr, []grpc.DialOption{grpc.WithInsecure()}...)
+			if err != nil {
+				return err
+			}
+
+			ackIds := collectAckIds(ackMsgs)
+			logger.Ctx(ctx).Infow("manager: modack proxy request", "proxyAddr", proxyAddr, "ackIds", ackIds)
+
+			proxyModAckRequest := &metrov1.ModifyAckDeadlineRequest{
+				Subscription: req.Subscription,
+				AckIds:       ackIds,
+				// pick up ack deadline time for any one of the message and set in the request
+				// this is usually the same for all given ack_ids
+				AckDeadlineSeconds: req.ModifyDeadlineMsgIdsWithSecs[ackMsgs[0].MessageID],
+			}
+			client := metrov1.NewSubscriberClient(conn)
+			_, aerr := client.ModifyAckDeadline(ctx, proxyModAckRequest)
+			if aerr != nil {
+				logger.Ctx(ctx).Errorw("manager: modack proxy request failed", "proxyAddr", proxyAddr, "error", aerr.Error())
+				// on error, try to proxy remaining requests
+				continue
+			}
+			logger.Ctx(ctx).Errorw("manager: modack proxy request succeeded", "proxyAddr", proxyAddr, "ackIds", ackIds)
+		}
+	}
 	return nil
 }
 

--- a/service/web/stream/manager.go
+++ b/service/web/stream/manager.go
@@ -217,7 +217,7 @@ func (s *Manager) ModifyAcknowledgement(ctx context.Context, req *ParsedStreamin
 				// on error, try to proxy remaining requests
 				continue
 			}
-			logger.Ctx(ctx).Errorw("manager: modack proxy request succeeded", "proxyAddr", proxyAddr, "ackIds", ackIds)
+			logger.Ctx(ctx).Infow("manager: modack proxy request succeeded", "proxyAddr", proxyAddr, "ackIds", ackIds)
 		}
 	}
 	return nil

--- a/service/web/stream/request.go
+++ b/service/web/stream/request.go
@@ -106,26 +106,28 @@ const (
 )
 
 type proxyRequest struct {
-	addr        string
-	ackMsgs     []*subscriber.AckMessage
-	parsedReq   *ParsedStreamingPullRequest
-	requestType requestType
+	addr           string
+	grpcServerAddr string
+	ackMsgs        []*subscriber.AckMessage
+	parsedReq      *ParsedStreamingPullRequest
+	requestType    requestType
 }
 
-func newAckProxyRequest(addr string, ackMsgs []*subscriber.AckMessage, parsedReq *ParsedStreamingPullRequest) *proxyRequest {
-	return newProxyRequest(addr, ackMsgs, parsedReq, ack)
+func newAckProxyRequest(addr string, ackMsgs []*subscriber.AckMessage, parsedReq *ParsedStreamingPullRequest, grpcServerAddr string) *proxyRequest {
+	return newProxyRequest(addr, ackMsgs, parsedReq, grpcServerAddr, ack)
 }
 
-func newModAckProxyRequest(addr string, ackMsgs []*subscriber.AckMessage, parsedReq *ParsedStreamingPullRequest) *proxyRequest {
-	return newProxyRequest(addr, ackMsgs, parsedReq, modAck)
+func newModAckProxyRequest(addr string, ackMsgs []*subscriber.AckMessage, parsedReq *ParsedStreamingPullRequest, grpcServerAddr string) *proxyRequest {
+	return newProxyRequest(addr, ackMsgs, parsedReq, grpcServerAddr, modAck)
 }
 
-func newProxyRequest(addr string, ackMsgs []*subscriber.AckMessage, parsedReq *ParsedStreamingPullRequest, requestType requestType) *proxyRequest {
+func newProxyRequest(addr string, ackMsgs []*subscriber.AckMessage, parsedReq *ParsedStreamingPullRequest, grpcServerAddr string, requestType requestType) *proxyRequest {
 	return &proxyRequest{
-		addr:        addr,
-		ackMsgs:     ackMsgs,
-		parsedReq:   parsedReq,
-		requestType: requestType,
+		addr:           addr,
+		grpcServerAddr: grpcServerAddr,
+		ackMsgs:        ackMsgs,
+		parsedReq:      parsedReq,
+		requestType:    requestType,
 	}
 }
 

--- a/service/web/stream/request.go
+++ b/service/web/stream/request.go
@@ -1,6 +1,7 @@
 package stream
 
 import (
+	"context"
 	"strings"
 
 	"github.com/razorpay/metro/internal/subscriber"
@@ -95,4 +96,34 @@ func NewParsedModifyAckDeadlineRequest(req *metrov1.ModifyAckDeadlineRequest) (*
 	}
 
 	return parsedReq, nil
+}
+
+// requestType specifies the type of proxy request, ack or modack
+type requestType int
+
+const (
+	ack requestType = iota
+	modAck
+)
+
+type proxyRequest struct {
+	ctx         context.Context
+	addr        string
+	ackMsgs     []*subscriber.AckMessage
+	parsedReq   *ParsedStreamingPullRequest
+	requestType requestType
+}
+
+func newProxyRequest(ctx context.Context, addr string, ackMsgs []*subscriber.AckMessage, parsedReq *ParsedStreamingPullRequest, requestType requestType) *proxyRequest {
+	return &proxyRequest{
+		ctx:         ctx,
+		addr:        addr,
+		ackMsgs:     ackMsgs,
+		parsedReq:   parsedReq,
+		requestType: requestType,
+	}
+}
+
+func (pr *proxyRequest) isAckRequestType() bool {
+	return pr.requestType == ack
 }

--- a/service/web/stream/request.go
+++ b/service/web/stream/request.go
@@ -1,7 +1,6 @@
 package stream
 
 import (
-	"context"
 	"strings"
 
 	"github.com/razorpay/metro/internal/subscriber"
@@ -107,16 +106,14 @@ const (
 )
 
 type proxyRequest struct {
-	ctx         context.Context
 	addr        string
 	ackMsgs     []*subscriber.AckMessage
 	parsedReq   *ParsedStreamingPullRequest
 	requestType requestType
 }
 
-func newProxyRequest(ctx context.Context, addr string, ackMsgs []*subscriber.AckMessage, parsedReq *ParsedStreamingPullRequest, requestType requestType) *proxyRequest {
+func newProxyRequest(addr string, ackMsgs []*subscriber.AckMessage, parsedReq *ParsedStreamingPullRequest, requestType requestType) *proxyRequest {
 	return &proxyRequest{
-		ctx:         ctx,
 		addr:        addr,
 		ackMsgs:     ackMsgs,
 		parsedReq:   parsedReq,

--- a/service/web/stream/request.go
+++ b/service/web/stream/request.go
@@ -112,6 +112,14 @@ type proxyRequest struct {
 	requestType requestType
 }
 
+func newAckProxyRequest(addr string, ackMsgs []*subscriber.AckMessage, parsedReq *ParsedStreamingPullRequest) *proxyRequest {
+	return newProxyRequest(addr, ackMsgs, parsedReq, ack)
+}
+
+func newModAckProxyRequest(addr string, ackMsgs []*subscriber.AckMessage, parsedReq *ParsedStreamingPullRequest) *proxyRequest {
+	return newProxyRequest(addr, ackMsgs, parsedReq, modAck)
+}
+
 func newProxyRequest(addr string, ackMsgs []*subscriber.AckMessage, parsedReq *ParsedStreamingPullRequest, requestType requestType) *proxyRequest {
 	return &proxyRequest{
 		addr:        addr,


### PR DESCRIPTION
**Message Ack stickiness due to Unary Ack / Nack / ModAck**

Ack/Nack/ModAck requests for messages can be load-balanced and land on a server that is not holding the message in memory. We need to proxy the message to the server from where it was delivered.
