### PR TITLE
log subscriber errors and continue the worker processing

### DIFF
--- a/service/worker/stream.go
+++ b/service/worker/stream.go
@@ -52,8 +52,6 @@ func (ps *PushStream) Start() error {
 		case <-gctx.Done():
 			err = gctx.Err()
 			logger.Ctx(ps.ctx).Infow("worker: subscriber stream context done", "error", err.Error())
-		case err = <-ps.subs.GetErrorChannel():
-			return err
 		case <-ps.stopCh:
 			logger.Ctx(ps.ctx).Infow("worker: subscriber stream received stop signal")
 			err = fmt.Errorf("stop channel received signal for stream, stopping")
@@ -68,6 +66,8 @@ func (ps *PushStream) Start() error {
 			select {
 			case <-gctx.Done():
 				return gctx.Err()
+			case err = <-ps.subs.GetErrorChannel():
+				logger.Ctx(ps.ctx).Errorw("worker: error from subscriber", "err", err.Error())
 			default:
 				logger.Ctx(ps.ctx).Debugw("worker: sending a subscriber pull request")
 				ps.subs.GetRequestChannel() <- &subscriber.PullRequest{10}


### PR DESCRIPTION
- Continue processing the subscriber and just logs the errors 