### PR TITLE
refactor channel hops

### DIFF
--- a/internal/subscriber/core.go
+++ b/internal/subscriber/core.go
@@ -2,6 +2,7 @@ package subscriber
 
 import (
 	"context"
+	"time"
 
 	"github.com/razorpay/metro/internal/brokerstore"
 	"github.com/razorpay/metro/internal/subscription"
@@ -72,7 +73,7 @@ func (c *Core) NewSubscriber(ctx context.Context, subscriberID string, subscript
 		closeChan:              make(chan struct{}),
 		ackChan:                make(chan *AckMessage),
 		modAckChan:             make(chan *ModAckMessage),
-		deadlineTickerChan:     make(chan bool),
+		deadlineTicker:         time.NewTicker(deadlineTickerInterval),
 		timeoutInMs:            timeoutInMs,
 		consumer:               consumer,
 		retryProducer:          retryProducer,

--- a/internal/subscriber/subscriber.go
+++ b/internal/subscriber/subscriber.go
@@ -18,6 +18,7 @@ import (
 )
 
 const (
+	deadlineTickerInterval  = 200 * time.Millisecond
 	minAckDeadline          = 10 * time.Minute
 	maxMessageRetryAttempts = 2
 )
@@ -54,9 +55,9 @@ type Subscriber struct {
 	responseChan           chan metrov1.PullResponse
 	ackChan                chan *AckMessage
 	modAckChan             chan *ModAckMessage
+	deadlineTicker         *time.Ticker
 	errChan                chan error
 	closeChan              chan struct{}
-	deadlineTickerChan     chan bool
 	timeoutInMs            int
 	consumer               messagebroker.Consumer // consume messages from primary topic
 	retryProducer          messagebroker.Producer // produce messages to retry topic
@@ -346,21 +347,6 @@ func (s *Subscriber) checkAndEvictBasedOnAckDeadline(ctx context.Context) {
 
 // Run loop
 func (s *Subscriber) Run(ctx context.Context) {
-	// for all requests keeping 200ms
-	go func(ctx context.Context, deadlineChan chan bool) {
-		ticker := time.NewTicker(time.Duration(200) * time.Millisecond)
-		for {
-			select {
-			case <-ticker.C:
-				deadlineChan <- true
-			case <-ctx.Done():
-				ticker.Stop()
-				close(deadlineChan)
-				return
-			}
-		}
-	}(ctx, s.deadlineTickerChan)
-
 	for {
 		select {
 		case req := <-s.requestChan:
@@ -457,10 +443,14 @@ func (s *Subscriber) Run(ctx context.Context) {
 			s.acknowledge(ctx, ackRequest)
 		case modAckRequest := <-s.modAckChan:
 			s.modifyAckDeadline(ctx, modAckRequest)
-		case <-s.deadlineTickerChan:
+		case <-s.deadlineTicker.C:
 			s.checkAndEvictBasedOnAckDeadline(ctx)
 		case <-ctx.Done():
 			logger.Ctx(s.ctx).Infow("subscriber: <-ctx.Done() called", "topic", s.topic, "subscription", s.subscription, "subscriberId", s.subscriberID)
+
+			// stop the ticker
+			s.deadlineTicker.Stop()
+
 			wasConsumerFound := s.bs.RemoveConsumer(s.ctx, s.subscriberID, messagebroker.ConsumerClientOptions{GroupID: s.subscription})
 			if wasConsumerFound {
 				// close consumer only if we are able to successfully find and delete consumer from the brokerStore.

--- a/service/worker/stream.go
+++ b/service/worker/stream.go
@@ -24,7 +24,6 @@ type PushStream struct {
 	subscriberCore   subscriber.ICore
 	subs             subscriber.ISubscriber
 	httpClient       http.Client
-	responseChan     chan metrov1.PullResponse
 	stopCh           chan struct{}
 	doneCh           chan struct{}
 }
@@ -68,9 +67,6 @@ func (ps *PushStream) Start() error {
 		for {
 			select {
 			case <-gctx.Done():
-				// close the response channel here, since this goroutine is the sender of the channel
-				close(ps.responseChan)
-
 				return gctx.Err()
 			case err = <-ps.subs.GetErrorChannel():
 				// if channel is closed, this can return with a nil error value
@@ -80,32 +76,18 @@ func (ps *PushStream) Start() error {
 				}
 			default:
 				logger.Ctx(ps.ctx).Infow("worker: sending a subscriber pull request", "subscription", ps.subcriptionName, "subscriberId", ps.subs.GetID())
-				ps.subs.GetRequestChannel() <- &subscriber.PullRequest{10}
+				ps.subs.GetRequestChannel() <- &subscriber.PullRequest{MaxNumOfMessages: 10}
 				logger.Ctx(ps.ctx).Infow("worker: waiting for subscriber data", "subscription", ps.subcriptionName, "subscriberId", ps.subs.GetID())
-				res := <-ps.subs.GetResponseChannel()
-				logger.Ctx(ps.ctx).Infow("worker: writing subscriber data to channel", "res", res, "count", len(res.ReceivedMessages), "subscription", ps.subcriptionName, "subscriberId", ps.subs.GetID())
-				ps.responseChan <- res
-			}
-		}
-		logger.Ctx(ps.ctx).Infow("worker: returning from pull stream go routine", "subscription", ps.subcriptionName, "subscriberId", ps.subs.GetID())
-		return nil
-	})
-
-	errGrp.Go(func() error {
-		// read from response channel and fire a webhook
-		for {
-			select {
-			case <-gctx.Done():
-				return gctx.Err()
-			default:
-				data := <-ps.responseChan
+				// wait for message to be available on the response channel
+				data := <-ps.subs.GetResponseChannel()
+				logger.Ctx(ps.ctx).Infow("worker: writing subscriber data to channel", "res", data, "count", len(data.ReceivedMessages), "subscription", ps.subcriptionName, "subscriberId", ps.subs.GetID())
 				if data.ReceivedMessages != nil && len(data.ReceivedMessages) > 0 {
 					logger.Ctx(ps.ctx).Infow("worker: reading response data from channel", "subscription", ps.subcriptionName, "subscriberId", ps.subs.GetID())
 					ps.processPushStreamResponse(ps.ctx, subModel, data)
 				}
 			}
 		}
-		logger.Ctx(ps.ctx).Infow("returning from webhook handler go routine", "subscription", ps.subcriptionName, "subscriberId", ps.subs.GetID())
+		logger.Ctx(ps.ctx).Infow("worker: returning from pull stream go routine", "subscription", ps.subcriptionName, "subscriberId", ps.subs.GetID())
 		return nil
 	})
 
@@ -115,7 +97,7 @@ func (ps *PushStream) Start() error {
 // Stop is used to terminate the push subscription processing
 func (ps *PushStream) Stop() error {
 	logger.Ctx(ps.ctx).Infow("worker: push stream stop invoked", "subscription", ps.subcriptionName, "subscriberId", ps.subs.GetID())
-	// Stop the pushsubscription
+	// Stop the push subscription
 	close(ps.stopCh)
 
 	// stop the subscriber
@@ -125,6 +107,7 @@ func (ps *PushStream) Stop() error {
 
 	// wait for stop to complete
 	<-ps.doneCh
+
 	return nil
 }
 
@@ -188,7 +171,6 @@ func NewPushStream(ctx context.Context, nodeID string, subName string, subscript
 		subscriberCore:   subscriberCore,
 		doneCh:           make(chan struct{}),
 		stopCh:           make(chan struct{}),
-		responseChan:     make(chan metrov1.PullResponse),
 		httpClient:       NewHTTPClientWithConfig(config),
 	}
 }

--- a/service/worker/stream.go
+++ b/service/worker/stream.go
@@ -74,18 +74,30 @@ func (ps *PushStream) Start() error {
 					logger.Ctx(ps.ctx).Errorw("worker: error from subscriber", "subscription", ps.subcriptionName, "subscriberId", ps.subs.GetID(), "err", err.Error())
 					workerSubscriberErrors.WithLabelValues(env, subModel.ExtractedTopicName, subModel.ExtractedSubscriptionName, err.Error()).Inc()
 				}
-			case data := <-ps.subs.GetResponseChannel():
-				logger.Ctx(ps.ctx).Infow("worker: writing subscriber data to channel", "res", data, "count", len(data.ReceivedMessages), "subscription", ps.subcriptionName, "subscriberId", ps.subs.GetID())
-				if data.ReceivedMessages != nil && len(data.ReceivedMessages) > 0 {
-					logger.Ctx(ps.ctx).Infow("worker: reading response data from channel", "subscription", ps.subcriptionName, "subscriberId", ps.subs.GetID())
-					ps.processPushStreamResponse(ps.ctx, subModel, data)
-				}
 			default:
 				logger.Ctx(ps.ctx).Infow("worker: sending a subscriber pull request", "subscription", ps.subcriptionName, "subscriberId", ps.subs.GetID())
 				ps.subs.GetRequestChannel() <- &subscriber.PullRequest{MaxNumOfMessages: 10}
 			}
 		}
 		logger.Ctx(ps.ctx).Infow("worker: returning from pull stream go routine", "subscription", ps.subcriptionName, "subscriberId", ps.subs.GetID())
+		return nil
+	})
+
+	errGrp.Go(func() error {
+		// Read from response channel and process push endpoint
+		for {
+			select {
+			case <-gctx.Done():
+				return gctx.Err()
+			case data := <-ps.subs.GetResponseChannel():
+				logger.Ctx(ps.ctx).Infow("worker: writing subscriber data to channel", "res", data, "count", len(data.ReceivedMessages), "subscription", ps.subcriptionName, "subscriberId", ps.subs.GetID())
+				if data.ReceivedMessages != nil && len(data.ReceivedMessages) > 0 {
+					logger.Ctx(ps.ctx).Infow("worker: reading response data from channel", "subscription", ps.subcriptionName, "subscriberId", ps.subs.GetID())
+					ps.processPushStreamResponse(ps.ctx, subModel, data)
+				}
+			}
+		}
+		logger.Ctx(ps.ctx).Infow("worker: returning from process push endpoint go routine", "subscription", ps.subcriptionName, "subscriberId", ps.subs.GetID())
 		return nil
 	})
 


### PR DESCRIPTION
- removes `responseChan` hop from `PushStream` in worker and directly listens on subscribers response chan.
- removes `deadlineTickerChan` from `Subscriber` and directly listens on the ticker channel.