### PR TITLE
adds tags to unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,19 +183,19 @@ docs-uml:
 
 .PHONY: test-integration-ci ## run integration tests on ci (github actions)
 test-integration-ci:
-	@METRO_TEST_HOST=metro-web KAFKA_TEST_HOST=kafka-broker go test ./... -tags=integration,musl
+	@METRO_TEST_HOST=metro-web KAFKA_TEST_HOST=kafka-broker go test ./tests/integration/... -tags=integration,musl
 
 .PHONY: test-integration ## run integration tests locally (metro service needs to be up)
 test-integration:
-	@METRO_TEST_HOST=localhost KAFKA_TEST_HOST=localhost go test --count=1 ./... -tags=integration,musl
+	@METRO_TEST_HOST=localhost KAFKA_TEST_HOST=localhost go test --count=1 ./tests/integration/... -tags=integration,musl
 
 .PHONY: test-compat-ci ## run compatibility tests on ci (github actions)
 test-compat-ci:
-	@METRO_TEST_HOST=metro-web PUBSUB_TEST_HOST=pubsub go test -v ./... -tags=compatibility,musl
+	@METRO_TEST_HOST=metro-web PUBSUB_TEST_HOST=pubsub go test -v ./tests/compatibility/... -tags=compatibility,musl
 
 .PHONY: test-compat ## run compatibility tests locally (metro service and pubsub emulator needs to be up)
 test-compat:
-	@METRO_TEST_HOST=localhost PUBSUB_TEST_HOST=localhost go test --count=1 -v ./... -tags=compatibility,musl
+	@METRO_TEST_HOST=localhost PUBSUB_TEST_HOST=localhost go test --count=1 -v ./tests/compatibility/... -tags=compatibility,musl
 
 .PHONY: test-unit-prepare
 test-unit-prepare:

--- a/cmd/service/metro/metro_test.go
+++ b/cmd/service/metro/metro_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package metro
 
 import (

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package app
 
 import (

--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package boot
 
 import (

--- a/internal/brokerstore/brokerstore_test.go
+++ b/internal/brokerstore/brokerstore_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package brokerstore
 
 import (

--- a/internal/common/model_test.go
+++ b/internal/common/model_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package common
 
 import (

--- a/internal/common/repo_test.go
+++ b/internal/common/repo_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package common
 
 import (

--- a/internal/health/core_test.go
+++ b/internal/health/core_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package health
 
 import (

--- a/internal/node/core_test.go
+++ b/internal/node/core_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package node
 
 import (

--- a/internal/node/model_test.go
+++ b/internal/node/model_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package node
 
 import (

--- a/internal/node/repo_test.go
+++ b/internal/node/repo_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package node
 
 import (

--- a/internal/nodebinding/core_test.go
+++ b/internal/nodebinding/core_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package nodebinding
 
 import (

--- a/internal/nodebinding/model_test.go
+++ b/internal/nodebinding/model_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package nodebinding
 
 import (

--- a/internal/nodebinding/repo_test.go
+++ b/internal/nodebinding/repo_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package nodebinding
 
 import (

--- a/internal/project/core_test.go
+++ b/internal/project/core_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package project
 
 import (

--- a/internal/project/model_test.go
+++ b/internal/project/model_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package project
 
 import (

--- a/internal/project/repo_test.go
+++ b/internal/project/repo_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package project
 
 import (

--- a/internal/project/validation_test.go
+++ b/internal/project/validation_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package project
 
 import (

--- a/internal/subscriber/customheap/deadline_based_test.go
+++ b/internal/subscriber/customheap/deadline_based_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package customheap
 
 import (

--- a/internal/subscriber/customheap/offset_based_test.go
+++ b/internal/subscriber/customheap/offset_based_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package customheap
 
 import (

--- a/internal/subscription/core_test.go
+++ b/internal/subscription/core_test.go
@@ -1,1 +1,3 @@
+// +build unit
+
 package subscription

--- a/internal/subscription/model_test.go
+++ b/internal/subscription/model_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package subscription
 
 import (

--- a/internal/subscription/validation_test.go
+++ b/internal/subscription/validation_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package subscription
 
 import (

--- a/internal/topic/core_test.go
+++ b/internal/topic/core_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package topic
 
 import (

--- a/internal/topic/model_test.go
+++ b/internal/topic/model_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package topic
 
 import (

--- a/internal/topic/validation_test.go
+++ b/internal/topic/validation_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package topic
 
 import (
@@ -5,7 +7,6 @@ import (
 	"testing"
 
 	metrov1 "github.com/razorpay/metro/rpc/proto/v1"
-
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package config
 
 import (

--- a/pkg/leaderelection/candidate_test.go
+++ b/pkg/leaderelection/candidate_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package leaderelection
 
 import (

--- a/pkg/leaderelection/config_test.go
+++ b/pkg/leaderelection/config_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package leaderelection
 
 import (

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package logger
 
 import (

--- a/pkg/messagebroker/utils_test.go
+++ b/pkg/messagebroker/utils_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package messagebroker
 
 import (

--- a/pkg/messagebroker/validations_test.go
+++ b/pkg/messagebroker/validations_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package messagebroker
 
 import (

--- a/pkg/monitoring/sentry/sentry_test.go
+++ b/pkg/monitoring/sentry/sentry_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package sentry
 
 import (

--- a/pkg/registry/consul_test.go
+++ b/pkg/registry/consul_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package registry
 
 import (

--- a/pkg/registry/factory_test.go
+++ b/pkg/registry/factory_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package registry
 
 import (

--- a/service/web/adminserver_test.go
+++ b/service/web/adminserver_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package web
 
 import (

--- a/service/web/publishserver_test.go
+++ b/service/web/publishserver_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package web
 
 import (

--- a/service/web/subscriberserver_test.go
+++ b/service/web/subscriberserver_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package web
 
 import (


### PR DESCRIPTION
- currently integration and compatibility tests also runs all unit tests as they are not tagged, adds `unit` tag to all tests which will help in excluding these tests from compat and integration test runs
- Adds a directory path for compat and integration test command to skip checking packages in other paths 
