### PR TITLE
handles rescheduling due to node failure

### DIFF
--- a/deployment/dev/docker-compose-datastores.yml
+++ b/deployment/dev/docker-compose-datastores.yml
@@ -66,6 +66,7 @@ services:
 
   consul:
     image: consul:1.9.0
+    hostname: consul
     container_name: metro-consul
     networks:
       - app-network

--- a/pkg/scheduler/loadbalancealgoimpl.go
+++ b/pkg/scheduler/loadbalancealgoimpl.go
@@ -21,7 +21,7 @@ func (p NodeCountList) Len() int           { return len(p) }
 func (p NodeCountList) Less(i, j int) bool { return p[i].Count < p[j].Count }
 func (p NodeCountList) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
 
-// LoadBalanceAlgoImpl implemnts load based scheduler algorithm
+// LoadBalanceAlgoImpl implements load based scheduler algorithm
 type LoadBalanceAlgoImpl struct {
 }
 

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -560,7 +560,7 @@ func (svc *Service) refreshNodeBindings(ctx context.Context) error {
 			return serr
 		}
 
-		serr = svc.scheduleSubscription(ctx, sub, nodeBindings)
+		serr = svc.scheduleSubscription(ctx, sub, &nodeBindings)
 		if serr != nil {
 			return serr
 		}
@@ -585,7 +585,7 @@ func (svc *Service) refreshNodeBindings(ctx context.Context) error {
 			}
 
 			for i := 0; i < topicM.NumPartitions; i++ {
-				serr := svc.scheduleSubscription(ctx, sub, nodeBindings)
+				serr := svc.scheduleSubscription(ctx, sub, &nodeBindings)
 				if serr != nil {
 					return serr
 				}
@@ -595,8 +595,8 @@ func (svc *Service) refreshNodeBindings(ctx context.Context) error {
 	return nil
 }
 
-func (svc *Service) scheduleSubscription(ctx context.Context, sub *subscription.Model, nodeBindings []*nodebinding.Model) error {
-	nb, serr := svc.scheduler.Schedule(sub, nodeBindings, svc.nodeCache)
+func (svc *Service) scheduleSubscription(ctx context.Context, sub *subscription.Model, nodeBindings *[]*nodebinding.Model) error {
+	nb, serr := svc.scheduler.Schedule(sub, *nodeBindings, svc.nodeCache)
 	if serr != nil {
 		return serr
 	}
@@ -606,7 +606,7 @@ func (svc *Service) scheduleSubscription(ctx context.Context, sub *subscription.
 		return berr
 	}
 
-	nodeBindings = append(nodeBindings, nb)
+	*nodeBindings = append(*nodeBindings, nb)
 	return nil
 }
 

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -503,27 +503,11 @@ func (svc *Service) refreshNodeBindings(ctx context.Context) error {
 		return err
 	}
 
+	// Delete any binding where subscription is removed, This needs to be handlled before nodes updates
+	// as node update will cause subscsriptions to be rescheduled on other nodes
 	validBindings := []*nodebinding.Model{}
-	// Delete any binding where node is removed
-	for _, nb := range nodeBindings {
-		found := false
-		for _, node := range svc.nodeCache {
-			if node.ID == nb.NodeID {
-				found = true
-				break
-			}
-		}
 
-		if !found {
-			svc.nodeBindingCore.DeleteNodeBinding(ctx, nb)
-		} else {
-			validBindings = append(validBindings, nb)
-		}
-	}
-	// update the binding list after deletions
-	nodeBindings = validBindings
-
-	// Delete any binding where subscription is removed
+	// TODO: Optimize O(N*M) to O(N+M)
 	for _, nb := range nodeBindings {
 		found := false
 		for _, sub := range svc.subCache {
@@ -542,6 +526,46 @@ func (svc *Service) refreshNodeBindings(ctx context.Context) error {
 	// update the binding list after deletions
 	nodeBindings = validBindings
 
+	// Reschedule any binding where node is removed
+	validBindings = []*nodebinding.Model{}
+	invalidBindings := []*nodebinding.Model{}
+
+	// TODO: Optimize O(N*M) to O(N+M)
+	for _, nb := range nodeBindings {
+		found := false
+		for _, node := range svc.nodeCache {
+			if node.ID == nb.NodeID {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			invalidBindings = append(invalidBindings, nb)
+			svc.nodeBindingCore.DeleteNodeBinding(ctx, nb)
+		} else {
+			validBindings = append(validBindings, nb)
+		}
+	}
+
+	// update the binding list after deletions
+	nodeBindings = validBindings
+
+	// Reschedule Bindings which are invalid due to node failures
+	for _, nb := range invalidBindings {
+		logger.Ctx(ctx).Infow("rescheduling subscription on nodes", "key", nb.SubscriptionID)
+
+		sub, serr := svc.subscriptionCore.Get(ctx, nb.SubscriptionID)
+		if serr != nil {
+			return serr
+		}
+
+		serr = svc.scheduleSubscription(ctx, sub, nodeBindings)
+		if serr != nil {
+			return serr
+		}
+	}
+
 	// Create bindings for new subscriptions
 	for _, sub := range svc.subCache {
 		found := false
@@ -553,7 +577,7 @@ func (svc *Service) refreshNodeBindings(ctx context.Context) error {
 		}
 
 		if !found {
-			logger.Ctx(ctx).Infow("scheduling subscription on nodes", "key", sub.Name)
+			logger.Ctx(ctx).Infow("scheduling subscription on nodes", "subscription", sub.Name, "topic", sub.Topic)
 
 			topicM, terr := svc.topicCore.Get(ctx, sub.Topic)
 			if terr != nil {
@@ -561,20 +585,28 @@ func (svc *Service) refreshNodeBindings(ctx context.Context) error {
 			}
 
 			for i := 0; i < topicM.NumPartitions; i++ {
-				nb, serr := svc.scheduler.Schedule(sub, nodeBindings, svc.nodeCache)
+				serr := svc.scheduleSubscription(ctx, sub, nodeBindings)
 				if serr != nil {
 					return serr
 				}
-
-				berr := svc.nodeBindingCore.CreateNodeBinding(ctx, nb)
-				if berr != nil {
-					return berr
-				}
-
-				nodeBindings = append(nodeBindings, nb)
 			}
 		}
 	}
+	return nil
+}
+
+func (svc *Service) scheduleSubscription(ctx context.Context, sub *subscription.Model, nodeBindings []*nodebinding.Model) error {
+	nb, serr := svc.scheduler.Schedule(sub, nodeBindings, svc.nodeCache)
+	if serr != nil {
+		return serr
+	}
+
+	berr := svc.nodeBindingCore.CreateNodeBinding(ctx, nb)
+	if berr != nil {
+		return berr
+	}
+
+	nodeBindings = append(nodeBindings, nb)
 	return nil
 }
 


### PR DESCRIPTION
Issue #125 
For node updates, if we find a binding which was associated with a deleted node, we should reschedule it (than deleting it)