### PR TITLE
App/Admin auth middleware impl

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,6 +72,7 @@ jobs:
           env:
             GIT_COMMIT_HASH: ${{ github.sha }}
             APP_ENV: dev_docker
+            EXEC_MODE: test
         - name: build mock server image
           uses: docker/build-push-action@v2
           with:
@@ -82,6 +83,7 @@ jobs:
           env:
             GIT_COMMIT_HASH: ${{ github.sha }}
             APP_ENV: dev_docker
+            EXEC_MODE: test
     integration-tests:
         runs-on: ubuntu-latest
         container: golang:1.15.5-alpine3.12
@@ -147,6 +149,7 @@ jobs:
                 APP_ENV: dev_docker
                 COMPONENT: web
                 GIT_COMMIT_HASH: ${{ github.sha }}
+                EXEC_MODE: test
               options: --health-cmd "nc -z localhost 8082"
             metro-worker:
               image: razorpay/metro:${{ github.sha }}
@@ -157,6 +160,7 @@ jobs:
                 APP_ENV: dev_docker
                 COMPONENT: worker
                 GIT_COMMIT_HASH: ${{ github.sha }}
+                EXEC_MODE: test
             mock-server:
               image: razorpay/metro:mock-subscriber-${{ github.sha }}
               ports:
@@ -164,6 +168,7 @@ jobs:
               env:
                 APP_ENV: dev_docker
                 GIT_COMMIT_HASH: ${{ github.sha }}
+                EXEC_MODE: test
             pubsub:
               image: adhawk/google-pubsub-emulator
               ports:

--- a/cmd/service/metro/component.go
+++ b/cmd/service/metro/component.go
@@ -24,7 +24,7 @@ func NewComponent(ctx context.Context, component string, cfg config.Config) (*Co
 
 	switch component {
 	case Web:
-		svc = web.NewService(ctx, &cfg.Web, &cfg.Registry)
+		svc = web.NewService(ctx, &cfg.Admin, &cfg.Web, &cfg.Registry)
 		config = cfg.Web
 	case Worker:
 		svc = worker.NewService(ctx, &cfg.Worker, &cfg.Registry)

--- a/config/default.toml
+++ b/config/default.toml
@@ -64,3 +64,7 @@
     httpServerAddress     = "0.0.0.0:3000"
     grpcGatewayAddress    = "localhost:8085"
     scheme                = "http"
+
+[admin]
+    username = ""
+    password = ""

--- a/config/dev_docker.toml
+++ b/config/dev_docker.toml
@@ -59,3 +59,7 @@
     httpServerAddress     = "0.0.0.0:3000"
     grpcGatewayAddress    = "localhost:8085"
     scheme                = "http"
+
+[admin]
+    username = "admin"
+    password = "supersecret"

--- a/config/func.toml
+++ b/config/func.toml
@@ -63,3 +63,7 @@
     httpServerAddress     = "0.0.0.0:3000"
     grpcGatewayAddress    = "localhost:8085"
     scheme                = "http"
+
+[admin]
+    username = "from_credstash"
+    password = "from_credstash"

--- a/config/perf.toml
+++ b/config/perf.toml
@@ -63,3 +63,7 @@
     httpServerAddress     = "0.0.0.0:3000"
     grpcGatewayAddress    = "localhost:8085"
     scheme                = "http"
+
+[admin]
+    username = "from_credstash"
+    password = "from_credstash"

--- a/config/stage.toml
+++ b/config/stage.toml
@@ -63,3 +63,7 @@
     httpServerAddress     = "0.0.0.0:3000"
     grpcGatewayAddress    = "localhost:8085"
     scheme                = "http"
+
+[admin]
+    username = "from_credstash"
+    password = "from_credstash"

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/apache/pulsar-client-go v0.3.0
 	github.com/apache/pulsar-client-go/oauth2 v0.0.0-20210115012126-2456729a54ca // indirect
 	github.com/armon/go-metrics v0.3.6 // indirect
+	github.com/bykof/go-plantuml v1.0.0 // indirect
 	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd // indirect
 	github.com/confluentinc/confluent-kafka-go v1.6.1
 	github.com/danieljoos/wincred v1.1.0 // indirect
@@ -52,14 +53,12 @@ require (
 	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.16.0
 	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad // indirect
-	golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5 // indirect
-	golang.org/x/net v0.0.0-20210331212208-0fccb6fa2b5c // indirect
+	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
 	golang.org/x/oauth2 v0.0.0-20210113205817-d3ed898aa8a3 // indirect
-	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
-	golang.org/x/sys v0.0.0-20210331175145-43e1dd70ce54 // indirect
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf // indirect
 	golang.org/x/text v0.3.6 // indirect
-	golang.org/x/tools v0.1.0 // indirect
+	golang.org/x/tools v0.1.2 // indirect
 	google.golang.org/api v0.36.0
 	google.golang.org/genproto v0.0.0-20210315173758-2651cd453018
 	google.golang.org/grpc v1.37.0-dev.0.20210309003715-fce74a94bdff

--- a/go.sum
+++ b/go.sum
@@ -90,6 +90,8 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
 github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b/go.mod h1:ac9efd0D1fsDb3EJvhqgXRbFx7bs2wqZ10HQPeU8U/Q=
 github.com/boynton/repl v0.0.0-20170116235056-348863958e3e/go.mod h1:Crc/GCZ3NXDVCio7Yr0o+SSrytpcFhLmVCIzi0s49t4=
+github.com/bykof/go-plantuml v1.0.0 h1:OvaiTwFC87UY0k4x+0m2E5ScJPSX2dyGKLAr0vr8Xmw=
+github.com/bykof/go-plantuml v1.0.0/go.mod h1:jZ9QvTC/efm6fsZUOv8X6EKhtTLL1W619ze60mPurCE=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
@@ -603,6 +605,7 @@ github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
@@ -662,6 +665,8 @@ golang.org/x/lint v0.0.0-20200130185559-910be7a94367/go.mod h1:3xt1FjdF8hUf6vQPI
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5 h1:2M3HP5CCK1Si9FQhwnzYhXdG6DXeebvUHFpre8QvbyI=
 golang.org/x/lint v0.0.0-20201208152925-83fdc39ff7b5/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
+golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 h1:VLliZ0d+/avPrXXH+OakdXhpJuEoBZuwh1m2j7U6Iug=
+golang.org/x/lint v0.0.0-20210508222113-6edffad5e616/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
@@ -673,6 +678,8 @@ golang.org/x/mod v0.3.0 h1:RM4zey1++hCTbCVQfnWeKs9/IEsaBLA8vTkd0WVtmH4=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.0 h1:8pl+sMODzuvGJkmj2W4kZihvVb5mKm8pB/X44PIQHv8=
 golang.org/x/mod v0.4.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.4.2 h1:Gz96sIWK3OalVv/I/qNygP42zyoKp3xptRVCWRFEBvo=
+golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -714,6 +721,8 @@ golang.org/x/net v0.0.0-20201031054903-ff519b6c9102/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210331212208-0fccb6fa2b5c h1:KHUzaHIpjWVlVVNh65G3hhuj3KB1HnjY6Cq5cTvRQT8=
 golang.org/x/net v0.0.0-20210331212208-0fccb6fa2b5c/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
+golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 h1:4nGaVu0QrbjT/AK2PRLuQfQuh6DJve+pELhqTdAj3x0=
+golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -733,6 +742,8 @@ golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9 h1:SQFwaSi55rU7vdNs9Yr0Z324VNlrF+0wMqRXT4St8ck=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
+golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -769,6 +780,7 @@ golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200106162015-b016eb3dc98e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200113162924-86b910548bc1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200121082415-34d275377bf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200122134326-e047566fdf82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200124204421-9fbb57f87de9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -793,6 +805,8 @@ golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210331175145-43e1dd70ce54 h1:rF3Ohx8DRyl8h2zw9qojyLHLhrJpEMgyPOImREEryf0=
 golang.org/x/sys v0.0.0-20210331175145-43e1dd70ce54/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210510120138-977fb7262007 h1:gG67DSER+11cZvqIMb8S8bt0vZtiN6xWYARwirrOSfE=
+golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20201210144234-2321bbc49cbf h1:MZ2shdL+ZM/XzY3ZGOnh4Nlpnxz5GSOhOmtHo3iPU6M=
@@ -868,6 +882,8 @@ golang.org/x/tools v0.0.0-20201201161351-ac6f37ff4c2a/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.0.0-20201202200335-bef1c476418a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0 h1:po9/4sTYwZU9lPhi1tOrb4hCv3qrhiQ77LZfGa2OjwY=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
+golang.org/x/tools v0.1.2 h1:kRBLX7v7Af8W7Gdbbc908OJcdgtK8bOz9Uaj8/F1ACA=
+golang.org/x/tools v0.1.2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -4,6 +4,12 @@ import (
 	"github.com/razorpay/metro/pkg/utils"
 )
 
+// IAuth define the auth model contract
+type IAuth interface {
+	GetUsername() string
+	GetPassword() string
+}
+
 // Auth holds basic auth credentials for push endpoint
 type Auth struct {
 	Username string `json:"username"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"github.com/razorpay/metro/internal/auth"
 	"github.com/razorpay/metro/pkg/monitoring/sentry"
 	"github.com/razorpay/metro/pkg/registry"
 	"github.com/razorpay/metro/pkg/tracing"
@@ -18,6 +19,7 @@ type Config struct {
 	Worker        worker.Config
 	Registry      registry.Config
 	OpenAPIServer openapiserver.Config
+	Admin         auth.Auth
 }
 
 // App contains application-specific config values

--- a/internal/interceptors/auth.go
+++ b/internal/interceptors/auth.go
@@ -24,7 +24,7 @@ var usernameRegex *regexp.Regexp
 
 func init() {
 	var err error
-	usernameRegex, err = regexp.Compile("([a-z][a-z0-9]{5,29})__[a-zA-Z0-9]{6}")
+	usernameRegex, err = regexp.Compile("([a-z][a-z0-9-]{5,29})__[a-zA-Z0-9]{6}")
 	if err != nil {
 		panic(err)
 	}

--- a/internal/interceptors/auth.go
+++ b/internal/interceptors/auth.go
@@ -1,0 +1,115 @@
+package interceptors
+
+import (
+	"context"
+	"crypto/subtle"
+	"encoding/base64"
+	"strings"
+
+	grpc_auth "github.com/grpc-ecosystem/go-grpc-middleware/auth"
+	"github.com/razorpay/metro/internal/auth"
+	"github.com/razorpay/metro/internal/project"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	authorizationHeaderKey = "authorization"
+)
+
+// UnaryServerAuthInterceptor creates an authenticator interceptor with the given AuthFunc
+func UnaryServerAuthInterceptor(authFunc grpc_auth.AuthFunc) grpc.UnaryServerInterceptor {
+	return grpc_auth.UnaryServerInterceptor(authFunc)
+}
+
+func getUserPassword(ctx context.Context) (user string, password []byte, err error) {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		err = status.Error(codes.Unauthenticated, "could not parse incoming context")
+		return
+	}
+
+	headers := md.Get(authorizationHeaderKey)
+	if len(headers) != 1 {
+		err = status.Error(codes.Unauthenticated, "invalid authorization header")
+		return
+	}
+
+	user, password, err = decodeAuthorizationHeader(headers[0])
+	return
+}
+
+func decodeAuthorizationHeader(header string) (user string, password []byte, err error) {
+	components := strings.Split(header, " ")
+	if len(components) != 2 || components[0] != "Basic" {
+		err = status.Error(codes.Unauthenticated, "authorization header malformed")
+		return
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(components[1])
+	if err != nil {
+		err = status.Error(codes.Unauthenticated, err.Error())
+		return
+	}
+
+	c := strings.Split(string(decoded), ":")
+	user, password = c[0], []byte(c[1])
+	return
+}
+
+// secureCompare: This function compares two values for their equality
+func secureCompare(expected, actual string) bool {
+	if subtle.ConstantTimeEq(int32(len(expected)), int32(len(actual))) == 1 {
+		return subtle.ConstantTimeCompare([]byte(expected), []byte(actual)) == 1
+	}
+
+	return false
+}
+
+// AppAuth implements app project based basic auth validations
+func AppAuth(ctx context.Context, projectCore project.ICore) (context.Context, error) {
+	user, password, err := getUserPassword(ctx)
+	if err != nil {
+		return ctx, err
+	}
+
+	if !strings.Contains(user, project.PartSeparator) {
+		return nil, status.Error(codes.Unauthenticated, "Unauthenticated")
+	}
+
+	projectID := strings.Split(user, project.PartSeparator)[0]
+
+	project, err := projectCore.Get(ctx, projectID)
+	if err != nil {
+		return ctx, err
+	}
+
+	if _, ok := project.AppAuth[user]; !ok {
+		return nil, status.Error(codes.Unauthenticated, "Unauthenticated")
+	}
+
+	authM := project.AppAuth[user]
+
+	expectedPassword := authM.GetPassword()
+	if !secureCompare(expectedPassword, string(password)) {
+		return nil, status.Error(codes.Unauthenticated, "Unauthenticated")
+	}
+
+	return ctx, nil
+}
+
+// AdminAuth implements admin credentials based basic auth validations
+func AdminAuth(ctx context.Context, admin *auth.Auth) (context.Context, error) {
+	user, password, err := getUserPassword(ctx)
+	if err != nil {
+		return ctx, err
+	}
+
+	if !secureCompare(admin.Username, string(user)) || !secureCompare(admin.Password, string(password)) {
+		return nil, status.Error(codes.Unauthenticated, "Unauthenticated")
+	}
+
+	return ctx, nil
+}

--- a/internal/project/validation.go
+++ b/internal/project/validation.go
@@ -16,7 +16,7 @@ var idRegex *regexp.Regexp
 
 func init() {
 	var err error
-	idRegex, err = regexp.Compile("([a-z][a-z0-9]{5,29})$")
+	idRegex, err = regexp.Compile("([a-z][a-z0-9-]{5,29})$")
 	if err != nil {
 		panic(err)
 	}

--- a/internal/project/validation.go
+++ b/internal/project/validation.go
@@ -16,7 +16,7 @@ var idRegex *regexp.Regexp
 
 func init() {
 	var err error
-	idRegex, err = regexp.Compile("([a-z][a-z0-9-]{5,29})$")
+	idRegex, err = regexp.Compile("([a-z][a-z0-9]{5,29})$")
 	if err != nil {
 		panic(err)
 	}

--- a/service/web/adminserver.go
+++ b/service/web/adminserver.go
@@ -179,6 +179,5 @@ func (s adminServer) DeleteProjectAccessKey(ctx context.Context, req *metrov1.Pr
 }
 
 func (s adminServer) AuthFuncOverride(ctx context.Context, _ string) (context.Context, error) {
-	//return appAuth(ctx , s.projectCore)
 	return interceptors.AdminAuth(ctx, s.admin)
 }

--- a/service/web/adminserver_test.go
+++ b/service/web/adminserver_test.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/razorpay/metro/internal/auth"
+
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/golang/mock/gomock"
@@ -29,7 +31,13 @@ func TestAdminServer_CreateProject(t *testing.T) {
 		ProjectId: "test-project-id",
 		Labels:    map[string]string{"foo": "bar"},
 	}
-	adminServer := newAdminServer(mockProjectCore, mockSubscriptionCore, mockTopicCOre, nil)
+
+	admin := &auth.Auth{
+		Username: "u",
+		Password: "p",
+	}
+
+	adminServer := newAdminServer(admin, mockProjectCore, mockSubscriptionCore, mockTopicCOre, nil)
 	ctx := context.Background()
 	projectModel, err := project.GetValidatedModelForCreate(ctx, projectProto)
 	assert.Nil(t, err)
@@ -50,7 +58,13 @@ func TestAdminServer_CreateProjectValidationFailure(t *testing.T) {
 		ProjectId: "test-project-id-",
 		Labels:    map[string]string{"foo": "bar"},
 	}
-	adminServer := newAdminServer(mockProjectCore, mockSubscriptionCore, mockTopicCOre, nil)
+
+	admin := &auth.Auth{
+		Username: "u",
+		Password: "p",
+	}
+
+	adminServer := newAdminServer(admin, mockProjectCore, mockSubscriptionCore, mockTopicCOre, nil)
 	ctx := context.Background()
 	p, err := adminServer.CreateProject(ctx, projectProto)
 	assert.Nil(t, p)
@@ -68,7 +82,13 @@ func TestAdminServer_CreateProjectFailure(t *testing.T) {
 		ProjectId: "test-project-id",
 		Labels:    map[string]string{"foo": "bar"},
 	}
-	adminServer := newAdminServer(mockProjectCore, mockSubscriptionCore, mockTopicCOre, nil)
+
+	admin := &auth.Auth{
+		Username: "u",
+		Password: "p",
+	}
+
+	adminServer := newAdminServer(admin, mockProjectCore, mockSubscriptionCore, mockTopicCOre, nil)
 	ctx := context.Background()
 	projectModel, err := project.GetValidatedModelForCreate(ctx, projectProto)
 	assert.Nil(t, err)
@@ -87,7 +107,13 @@ func TestAdminServer_DeleteProject(t *testing.T) {
 	projectProto := &metrov1.Project{
 		ProjectId: "test-project-id",
 	}
-	adminServer := newAdminServer(mockProjectCore, mockSubscriptionCore, mockTopicCore, nil)
+
+	admin := &auth.Auth{
+		Username: "u",
+		Password: "p",
+	}
+
+	adminServer := newAdminServer(admin, mockProjectCore, mockSubscriptionCore, mockTopicCore, nil)
 	ctx := context.Background()
 	projectModel, err := project.GetValidatedModelForDelete(ctx, projectProto)
 	assert.Nil(t, err)
@@ -109,7 +135,12 @@ func TestAdminServer_DeleteProjectValidationFailure(t *testing.T) {
 	projectProto := &metrov1.Project{
 		ProjectId: "",
 	}
-	adminServer := newAdminServer(mockProjectCore, mockSubscriptionCore, mockTopicCore, nil)
+
+	admin := &auth.Auth{
+		Username: "u",
+		Password: "p",
+	}
+	adminServer := newAdminServer(admin, mockProjectCore, mockSubscriptionCore, mockTopicCore, nil)
 	ctx := context.Background()
 
 	p, err := adminServer.DeleteProject(ctx, projectProto)

--- a/service/web/publishserver_test.go
+++ b/service/web/publishserver_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	mocks "github.com/razorpay/metro/internal/brokerstore/mocks"
+	mocks5 "github.com/razorpay/metro/internal/project/mocks/core"
 	mocks3 "github.com/razorpay/metro/internal/publisher/mocks/core"
 	"github.com/razorpay/metro/internal/topic"
 	mocks2 "github.com/razorpay/metro/internal/topic/mocks/core"
@@ -24,7 +25,8 @@ func TestPublishServer_CreateTopicSuccess(t *testing.T) {
 	topicCore := mocks2.NewMockICore(ctrl)
 	publisher := mocks3.NewMockIPublisher(ctrl)
 	admin := mocks4.NewMockAdmin(ctrl)
-	server := newPublisherServer(brokerStore, topicCore, publisher)
+	mockProjectCore := mocks5.NewMockICore(ctrl)
+	server := newPublisherServer(mockProjectCore, brokerStore, topicCore, publisher)
 
 	ctx := context.Background()
 	req := &metrov1.Topic{
@@ -45,10 +47,11 @@ func TestPublishServer_CreateTopicSuccess(t *testing.T) {
 
 func TestPublishServer_CreateTopicFailure(t *testing.T) {
 	ctrl := gomock.NewController(t)
+	mockProjectCore := mocks5.NewMockICore(ctrl)
 	brokerStore := mocks.NewMockIBrokerStore(ctrl)
 	topicCore := mocks2.NewMockICore(ctrl)
 	publisher := mocks3.NewMockIPublisher(ctrl)
-	server := newPublisherServer(brokerStore, topicCore, publisher)
+	server := newPublisherServer(mockProjectCore, brokerStore, topicCore, publisher)
 
 	ctx := context.Background()
 	req := &metrov1.Topic{
@@ -65,10 +68,11 @@ func TestPublishServer_CreateTopicFailure(t *testing.T) {
 
 func TestPublishServer_DeleteTopicSuccess(t *testing.T) {
 	ctrl := gomock.NewController(t)
+	mockProjectCore := mocks5.NewMockICore(ctrl)
 	brokerStore := mocks.NewMockIBrokerStore(ctrl)
 	topicCore := mocks2.NewMockICore(ctrl)
 	publisher := mocks3.NewMockIPublisher(ctrl)
-	server := newPublisherServer(brokerStore, topicCore, publisher)
+	server := newPublisherServer(mockProjectCore, brokerStore, topicCore, publisher)
 
 	ctx := context.Background()
 	req := &metrov1.DeleteTopicRequest{
@@ -85,10 +89,11 @@ func TestPublishServer_DeleteTopicSuccess(t *testing.T) {
 
 func TestPublishServer_DeleteTopicFailure(t *testing.T) {
 	ctrl := gomock.NewController(t)
+	mockProjectCore := mocks5.NewMockICore(ctrl)
 	brokerStore := mocks.NewMockIBrokerStore(ctrl)
 	topicCore := mocks2.NewMockICore(ctrl)
 	publisher := mocks3.NewMockIPublisher(ctrl)
-	server := newPublisherServer(brokerStore, topicCore, publisher)
+	server := newPublisherServer(mockProjectCore, brokerStore, topicCore, publisher)
 
 	ctx := context.Background()
 	req := &metrov1.DeleteTopicRequest{
@@ -104,10 +109,11 @@ func TestPublishServer_DeleteTopicFailure(t *testing.T) {
 
 func TestPublishServer_PublishSuccess(t *testing.T) {
 	ctrl := gomock.NewController(t)
+	mockProjectCore := mocks5.NewMockICore(ctrl)
 	brokerStore := mocks.NewMockIBrokerStore(ctrl)
 	topicCore := mocks2.NewMockICore(ctrl)
 	publisher := mocks3.NewMockIPublisher(ctrl)
-	server := newPublisherServer(brokerStore, topicCore, publisher)
+	server := newPublisherServer(mockProjectCore, brokerStore, topicCore, publisher)
 
 	ctx := context.Background()
 	req := &metrov1.PublishRequest{
@@ -123,10 +129,11 @@ func TestPublishServer_PublishSuccess(t *testing.T) {
 
 func TestPublishServer_PublishFailure(t *testing.T) {
 	ctrl := gomock.NewController(t)
+	mockProjectCore := mocks5.NewMockICore(ctrl)
 	brokerStore := mocks.NewMockIBrokerStore(ctrl)
 	topicCore := mocks2.NewMockICore(ctrl)
 	publisher := mocks3.NewMockIPublisher(ctrl)
-	server := newPublisherServer(brokerStore, topicCore, publisher)
+	server := newPublisherServer(mockProjectCore, brokerStore, topicCore, publisher)
 
 	ctx := context.Background()
 	req := &metrov1.PublishRequest{
@@ -142,10 +149,11 @@ func TestPublishServer_PublishFailure(t *testing.T) {
 
 func TestPublishServer_PublishFailure_OnWrongTopic(t *testing.T) {
 	ctrl := gomock.NewController(t)
+	mockProjectCore := mocks5.NewMockICore(ctrl)
 	brokerStore := mocks.NewMockIBrokerStore(ctrl)
 	topicCore := mocks2.NewMockICore(ctrl)
 	publisher := mocks3.NewMockIPublisher(ctrl)
-	server := newPublisherServer(brokerStore, topicCore, publisher)
+	server := newPublisherServer(mockProjectCore, brokerStore, topicCore, publisher)
 
 	ctx := context.Background()
 	req := &metrov1.PublishRequest{

--- a/service/web/service.go
+++ b/service/web/service.go
@@ -3,6 +3,7 @@ package web
 import (
 	"context"
 	"net/http"
+	"os"
 
 	"github.com/razorpay/metro/internal/interceptors"
 
@@ -163,6 +164,11 @@ func (svc *Service) Stop() error {
 }
 
 func getInterceptors() []grpc.UnaryServerInterceptor {
+	// skip auth from test mode executions
+	if os.Getenv("EXEC_MODE") == "test" {
+		return []grpc.UnaryServerInterceptor{}
+	}
+
 	return []grpc.UnaryServerInterceptor{
 		interceptors.UnaryServerAuthInterceptor(func(ctx context.Context) (context.Context, error) {
 			return ctx, nil

--- a/service/web/subscriberserver_test.go
+++ b/service/web/subscriberserver_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/razorpay/metro/internal/brokerstore/mocks"
+	mocks4 "github.com/razorpay/metro/internal/project/mocks/core"
 	"github.com/razorpay/metro/internal/subscription"
 	mocks2 "github.com/razorpay/metro/internal/subscription/mocks/core"
 	metrov1 "github.com/razorpay/metro/rpc/proto/v1"
@@ -20,10 +21,11 @@ import (
 
 func TestSubscriberServer_CreateSubscription(t *testing.T) {
 	ctrl := gomock.NewController(t)
+	mockProjectCore := mocks4.NewMockICore(ctrl)
 	brokerStore := mocks.NewMockIBrokerStore(ctrl)
 	subscriptionCore := mocks2.NewMockICore(ctrl)
 	manager := mocks3.NewMockIManager(ctrl)
-	server := newSubscriberServer(brokerStore, subscriptionCore, manager)
+	server := newSubscriberServer(mockProjectCore, brokerStore, subscriptionCore, manager)
 
 	ctx := context.Background()
 	req := &metrov1.Subscription{
@@ -42,10 +44,11 @@ func TestSubscriberServer_CreateSubscription(t *testing.T) {
 
 func TestSubscriberServer_CreateSubscriptionFailure(t *testing.T) {
 	ctrl := gomock.NewController(t)
+	mockProjectCore := mocks4.NewMockICore(ctrl)
 	brokerStore := mocks.NewMockIBrokerStore(ctrl)
 	subscriptionCore := mocks2.NewMockICore(ctrl)
 	manager := mocks3.NewMockIManager(ctrl)
-	server := newSubscriberServer(brokerStore, subscriptionCore, manager)
+	server := newSubscriberServer(mockProjectCore, brokerStore, subscriptionCore, manager)
 
 	ctx := context.Background()
 	req := &metrov1.Subscription{
@@ -64,10 +67,11 @@ func TestSubscriberServer_CreateSubscriptionFailure(t *testing.T) {
 
 func TestSubscriberServer_Acknowledge(t *testing.T) {
 	ctrl := gomock.NewController(t)
+	mockProjectCore := mocks4.NewMockICore(ctrl)
 	brokerStore := mocks.NewMockIBrokerStore(ctrl)
 	subscriptionCore := mocks2.NewMockICore(ctrl)
 	manager := mocks3.NewMockIManager(ctrl)
-	server := newSubscriberServer(brokerStore, subscriptionCore, manager)
+	server := newSubscriberServer(mockProjectCore, brokerStore, subscriptionCore, manager)
 
 	ctx := context.Background()
 	req := &metrov1.AcknowledgeRequest{
@@ -86,10 +90,11 @@ func TestSubscriberServer_Acknowledge(t *testing.T) {
 
 func TestSubscriberServer_AcknowledgeFailure(t *testing.T) {
 	ctrl := gomock.NewController(t)
+	mockProjectCore := mocks4.NewMockICore(ctrl)
 	brokerStore := mocks.NewMockIBrokerStore(ctrl)
 	subscriptionCore := mocks2.NewMockICore(ctrl)
 	manager := mocks3.NewMockIManager(ctrl)
-	server := newSubscriberServer(brokerStore, subscriptionCore, manager)
+	server := newSubscriberServer(mockProjectCore, brokerStore, subscriptionCore, manager)
 
 	ctx := context.Background()
 	req := &metrov1.AcknowledgeRequest{
@@ -108,10 +113,11 @@ func TestSubscriberServer_AcknowledgeFailure(t *testing.T) {
 
 func TestSubscriberServer_Pull(t *testing.T) {
 	ctrl := gomock.NewController(t)
+	mockProjectCore := mocks4.NewMockICore(ctrl)
 	brokerStore := mocks.NewMockIBrokerStore(ctrl)
 	subscriptionCore := mocks2.NewMockICore(ctrl)
 	manager := mocks3.NewMockIManager(ctrl)
-	server := newSubscriberServer(brokerStore, subscriptionCore, manager)
+	server := newSubscriberServer(mockProjectCore, brokerStore, subscriptionCore, manager)
 
 	ctx := context.Background()
 	req := &metrov1.PullRequest{
@@ -127,10 +133,11 @@ func TestSubscriberServer_Pull(t *testing.T) {
 
 func TestSubscriberServer_DeleteSubscription(t *testing.T) {
 	ctrl := gomock.NewController(t)
+	mockProjectCore := mocks4.NewMockICore(ctrl)
 	brokerStore := mocks.NewMockIBrokerStore(ctrl)
 	subscriptionCore := mocks2.NewMockICore(ctrl)
 	manager := mocks3.NewMockIManager(ctrl)
-	server := newSubscriberServer(brokerStore, subscriptionCore, manager)
+	server := newSubscriberServer(mockProjectCore, brokerStore, subscriptionCore, manager)
 
 	ctx := context.Background()
 	req := &metrov1.DeleteSubscriptionRequest{
@@ -148,10 +155,11 @@ func TestSubscriberServer_DeleteSubscription(t *testing.T) {
 
 func TestSubscriberServer_DeleteSubscriptionFailure(t *testing.T) {
 	ctrl := gomock.NewController(t)
+	mockProjectCore := mocks4.NewMockICore(ctrl)
 	brokerStore := mocks.NewMockIBrokerStore(ctrl)
 	subscriptionCore := mocks2.NewMockICore(ctrl)
 	manager := mocks3.NewMockIManager(ctrl)
-	server := newSubscriberServer(brokerStore, subscriptionCore, manager)
+	server := newSubscriberServer(mockProjectCore, brokerStore, subscriptionCore, manager)
 
 	ctx := context.Background()
 	req := &metrov1.DeleteSubscriptionRequest{
@@ -169,10 +177,11 @@ func TestSubscriberServer_DeleteSubscriptionFailure(t *testing.T) {
 
 func TestSubscriberServer_ModifyAckDeadline(t *testing.T) {
 	ctrl := gomock.NewController(t)
+	mockProjectCore := mocks4.NewMockICore(ctrl)
 	brokerStore := mocks.NewMockIBrokerStore(ctrl)
 	subscriptionCore := mocks2.NewMockICore(ctrl)
 	manager := mocks3.NewMockIManager(ctrl)
-	server := newSubscriberServer(brokerStore, subscriptionCore, manager)
+	server := newSubscriberServer(mockProjectCore, brokerStore, subscriptionCore, manager)
 
 	ctx := context.Background()
 	req := &metrov1.ModifyAckDeadlineRequest{
@@ -192,10 +201,11 @@ func TestSubscriberServer_ModifyAckDeadline(t *testing.T) {
 
 func TestSubscriberServer_ModifyAckDeadlineFailure(t *testing.T) {
 	ctrl := gomock.NewController(t)
+	mockProjectCore := mocks4.NewMockICore(ctrl)
 	brokerStore := mocks.NewMockIBrokerStore(ctrl)
 	subscriptionCore := mocks2.NewMockICore(ctrl)
 	manager := mocks3.NewMockIManager(ctrl)
-	server := newSubscriberServer(brokerStore, subscriptionCore, manager)
+	server := newSubscriberServer(mockProjectCore, brokerStore, subscriptionCore, manager)
 
 	ctx := context.Background()
 	req := &metrov1.ModifyAckDeadlineRequest{
@@ -215,8 +225,9 @@ func TestSubscriberServer_ModifyAckDeadlineFailure(t *testing.T) {
 
 func TestSubscriberServer_StreamingPull(t *testing.T) {
 	ctrl := gomock.NewController(t)
+	mockProjectCore := mocks4.NewMockICore(ctrl)
 	brokerStore := mocks.NewMockIBrokerStore(ctrl)
 	subscriptionCore := mocks2.NewMockICore(ctrl)
 	manager := mocks3.NewMockIManager(ctrl)
-	newSubscriberServer(brokerStore, subscriptionCore, manager)
+	newSubscriberServer(mockProjectCore, brokerStore, subscriptionCore, manager)
 }


### PR DESCRIPTION
**Implements two specific auth middlewares**
- `Admin Auth`: These creds would be read from the config injected via env.
- `App Auth`: These are project-specific access key pairs generated via the Admin APIs. Ideally, every project would get a unique access key pair.