### PR TITLE
fixes theme attribute in docs

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -28,7 +28,7 @@ twitter_username: razorpay
 github_username:  razorpay
 
 # Build settings
-theme: "just-the-docs"
+remote_theme: "pmarsceill/just-the-docs"
 plugins:
   - jekyll-feed
 


### PR DESCRIPTION
https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/adding-a-theme-to-your-github-pages-site-using-jekyll

since we are using a remote theme, fixing the attribute