### PR TITLE
Metro Docs: fix for base url

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -21,9 +21,7 @@
 title: Razorpay Metro
 email: sunny.aggrawal@razorpay.com
 description: >- # this means to ignore newlines until "baseurl:"
-  Metro pubsub based is a messaging service.
-baseurl: "/" # the subpath of your site, e.g. /blog
-url: "https://razorpay.github.io/metro" # the base hostname & protocol for your site, e.g. http://example.com
+  Metro is a pubsub based messaging service.
 
 # Build settings
 remote_theme: "pmarsceill/just-the-docs"


### PR DESCRIPTION
- fixes docs path prefix (removes extra /metro)