### PR TITLE
fixes grpc version to v2.4.0 as lastest version is breaking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,8 +77,8 @@ deps: buf-deps
 	# https://github.com/johanbrandhorst/grpc-gateway-boilerplate/blob/master/Makefile
 	@go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
 	@go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
-	@go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway@latest
-	@go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2@latest
+	@go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway@v2.4.0
+	@go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2@v2.4.0
 	@go install github.com/rakyll/statik@latest
 	@go install golang.org/x/lint/golint@latest
 	@go install github.com/bykof/go-plantuml@v1.0.0


### PR DESCRIPTION
2.5.0 latest version is breaking, keeping that for debugging and fixing master for now by fixing version to 2.4.0