### PR TITLE
Edit subscription worker

### DIFF
--- a/internal/common/model.go
+++ b/internal/common/model.go
@@ -1,6 +1,13 @@
 package common
 
-import "github.com/razorpay/metro/internal/app"
+import (
+	"fmt"
+
+	"github.com/razorpay/metro/internal/app"
+)
+
+// Version of key value pair provided by the registry. Version changes on every update
+type VersionID string
 
 // IModel interface which all models should implement
 type IModel interface {
@@ -8,10 +15,32 @@ type IModel interface {
 	Key() string
 	// Prefix returns the key prefix used by the module
 	Prefix() string
+	// Returns the version of the saved model in the registry. Version changes for every update.
+	GetVersionID() (string, error)
+	//Sets the version of the saved model from the registry. Never to be used by business logic.
+	SetVersionID(vid string)
 }
 
 // BaseModel implements basic model functionality
-type BaseModel struct{}
+type BaseModel struct {
+	versionID    string
+	isVersionSet bool
+}
+
+//Base implementation of set version id
+func (b *BaseModel) SetVersionID(vid string) {
+	b.isVersionSet = true
+	b.versionID = vid
+}
+
+//Base implementation of get version id. errors out if called without setting the version id.
+func (b *BaseModel) GetVersionID() (string, error) {
+	if !b.isVersionSet {
+		err := fmt.Errorf("calling getVersionID without setting it")
+		return "", err
+	}
+	return b.versionID, nil
+}
 
 // GetBasePrefix returns the prefix
 func GetBasePrefix() string {

--- a/internal/common/model.go
+++ b/internal/common/model.go
@@ -1,9 +1,11 @@
 package common
 
 import (
-	"fmt"
-
 	"github.com/razorpay/metro/internal/app"
+)
+
+const (
+	defaultVersion string = "0"
 )
 
 // IModel interface which all models should implement
@@ -13,30 +15,27 @@ type IModel interface {
 	// Prefix returns the key prefix used by the module
 	Prefix() string
 	// Returns the version of the saved model in the registry. Version changes for every update.
-	GetVersionID() (string, error)
+	GetVersion() string
 	//Sets the version of the saved model from the registry. Never to be used by business logic.
-	SetVersionID(vid string)
+	SetVersion(version string)
 }
 
 // BaseModel implements basic model functionality
 type BaseModel struct {
-	versionID    string
-	isVersionSet bool
+	version *string
 }
 
-//SetVersionID Base implementation of set version id
-func (b *BaseModel) SetVersionID(vid string) {
-	b.isVersionSet = true
-	b.versionID = vid
+//SetVersion Base implementation of set version
+func (b *BaseModel) SetVersion(version string) {
+	b.version = &version
 }
 
-//GetVersionID Base implementation of get version id. errors out if called without setting the version id.
-func (b *BaseModel) GetVersionID() (string, error) {
-	if !b.isVersionSet {
-		err := fmt.Errorf("calling getVersionID without setting it")
-		return "", err
+//GetVersion Base implementation of get version. Default version is "0".
+func (b *BaseModel) GetVersion() string {
+	if b.version == nil {
+		return defaultVersion
 	}
-	return b.versionID, nil
+	return *b.version
 }
 
 // GetBasePrefix returns the prefix

--- a/internal/common/model.go
+++ b/internal/common/model.go
@@ -6,9 +6,6 @@ import (
 	"github.com/razorpay/metro/internal/app"
 )
 
-// Version of key value pair provided by the registry. Version changes on every update
-type VersionID string
-
 // IModel interface which all models should implement
 type IModel interface {
 	// Key returns the key to store the model against
@@ -27,13 +24,13 @@ type BaseModel struct {
 	isVersionSet bool
 }
 
-//Base implementation of set version id
+//SetVersionID Base implementation of set version id
 func (b *BaseModel) SetVersionID(vid string) {
 	b.isVersionSet = true
 	b.versionID = vid
 }
 
-//Base implementation of get version id. errors out if called without setting the version id.
+//GetVersionID Base implementation of get version id. errors out if called without setting the version id.
 func (b *BaseModel) GetVersionID() (string, error) {
 	if !b.isVersionSet {
 		err := fmt.Errorf("calling getVersionID without setting it")

--- a/internal/common/model_test.go
+++ b/internal/common/model_test.go
@@ -13,3 +13,16 @@ import (
 func TestBaseModel_Prefix(t *testing.T) {
 	assert.Equal(t, "metro-"+app.GetEnv()+"/", GetBasePrefix())
 }
+
+func TestSetVersionID(t *testing.T) {
+	m := BaseModel{}
+	m.SetVersionID("v1")
+	vid, _ := m.GetVersionID()
+	assert.Equal(t, "v1", vid)
+}
+
+func TestGetVersionIDUnset(t *testing.T) {
+	m := BaseModel{}
+	_, err := m.GetVersionID()
+	assert.NotNil(t, err)
+}

--- a/internal/common/model_test.go
+++ b/internal/common/model_test.go
@@ -14,15 +14,15 @@ func TestBaseModel_Prefix(t *testing.T) {
 	assert.Equal(t, "metro-"+app.GetEnv()+"/", GetBasePrefix())
 }
 
-func TestSetVersionID(t *testing.T) {
+func TestSetVersion(t *testing.T) {
 	m := BaseModel{}
-	m.SetVersionID("v1")
-	vid, _ := m.GetVersionID()
-	assert.Equal(t, "v1", vid)
+	m.SetVersion("v1")
+	ver := m.GetVersion()
+	assert.Equal(t, "v1", ver)
 }
 
-func TestGetVersionIDUnset(t *testing.T) {
+func TestGetVersionUnset(t *testing.T) {
 	m := BaseModel{}
-	_, err := m.GetVersionID()
-	assert.NotNil(t, err)
+	ver := m.GetVersion()
+	assert.Equal(t, ver, "0")
 }

--- a/internal/common/repo.go
+++ b/internal/common/repo.go
@@ -38,9 +38,9 @@ func (r BaseRepo) Save(ctx context.Context, m IModel) error {
 		return err
 	}
 
-	vid, err := r.Registry.Put(ctx, m.Key(), b)
+	version, err := r.Registry.Put(ctx, m.Key(), b)
 	if err == nil {
-		m.SetVersionID(vid)
+		m.SetVersion(version)
 	}
 
 	return err
@@ -105,7 +105,7 @@ func (r BaseRepo) Get(ctx context.Context, key string, m IModel) error {
 	if err != nil {
 		return err
 	}
-	m.SetVersionID(p.VersionID)
+	m.SetVersion(p.Version)
 	return nil
 }
 

--- a/internal/common/repo_test.go
+++ b/internal/common/repo_test.go
@@ -18,9 +18,9 @@ func (s *sampleModel) Key() string { return "sample-key" }
 
 func (s *sampleModel) Prefix() string { return "sample-prefix" }
 
-func (s *sampleModel) SetVersionID(vid string) {}
+func (s *sampleModel) SetVersion(version string) {}
 
-func (s *sampleModel) GetVersionID() (string, error) { return "", nil }
+func (s *sampleModel) GetVersion() string { return "0" }
 
 func TestBaseRepo_Save(t *testing.T) {
 	ctrl := gomock.NewController(t)

--- a/internal/common/repo_test.go
+++ b/internal/common/repo_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/razorpay/metro/pkg/registry"
 	"github.com/razorpay/metro/pkg/registry/mocks"
 	"github.com/stretchr/testify/assert"
 )
@@ -16,6 +17,10 @@ type sampleModel struct{}
 func (s *sampleModel) Key() string { return "sample-key" }
 
 func (s *sampleModel) Prefix() string { return "sample-prefix" }
+
+func (s *sampleModel) SetVersionID(vid string) {}
+
+func (s *sampleModel) GetVersionID() (string, error) { return "", nil }
 
 func TestBaseRepo_Save(t *testing.T) {
 	ctrl := gomock.NewController(t)
@@ -53,7 +58,7 @@ func TestBaseRepo_Get(t *testing.T) {
 	mockRegistry := mocks.NewMockIRegistry(ctrl)
 	repo := &BaseRepo{mockRegistry}
 	ctx := context.Background()
-	mockRegistry.EXPECT().Get(gomock.Any(), "sample-key").Return([]byte("{}"), nil)
+	mockRegistry.EXPECT().Get(gomock.Any(), "sample-key").Return(registry.Pair{Key: "sample-key", Value: []byte("{}")}, nil)
 
 	var model sampleModel
 	err := repo.Get(ctx, "sample-key", &model)

--- a/internal/common/repo_test.go
+++ b/internal/common/repo_test.go
@@ -58,7 +58,7 @@ func TestBaseRepo_Get(t *testing.T) {
 	mockRegistry := mocks.NewMockIRegistry(ctrl)
 	repo := &BaseRepo{mockRegistry}
 	ctx := context.Background()
-	mockRegistry.EXPECT().Get(gomock.Any(), "sample-key").Return(registry.Pair{Key: "sample-key", Value: []byte("{}")}, nil)
+	mockRegistry.EXPECT().Get(gomock.Any(), "sample-key").Return(&registry.Pair{Key: "sample-key", Value: []byte("{}")}, nil)
 
 	var model sampleModel
 	err := repo.Get(ctx, "sample-key", &model)

--- a/internal/node/repo.go
+++ b/internal/node/repo.go
@@ -44,7 +44,7 @@ func (r *Repo) List(ctx context.Context, prefix string) ([]common.IModel, error)
 		if err != nil {
 			return nil, err
 		}
-		m.SetVersionID(pair.VersionID)
+		m.SetVersion(pair.Version)
 		models = append(models, &m)
 	}
 	return models, nil

--- a/internal/node/repo.go
+++ b/internal/node/repo.go
@@ -44,6 +44,7 @@ func (r *Repo) List(ctx context.Context, prefix string) ([]common.IModel, error)
 		if err != nil {
 			return nil, err
 		}
+		m.SetVersionID(pair.VersionID)
 		models = append(models, &m)
 	}
 	return models, nil

--- a/internal/nodebinding/model.go
+++ b/internal/nodebinding/model.go
@@ -14,10 +14,10 @@ const (
 // Model for a node
 type Model struct {
 	common.BaseModel
-	ID                    string `json:"id"`
-	NodeID                string `json:"node_id"`
-	SubscriptionID        string `json:"subscription_id"`
-	SubscriptionVersionID string `json:"subscription_version_id"`
+	ID                  string `json:"id"`
+	NodeID              string `json:"node_id"`
+	SubscriptionID      string `json:"subscription_id"`
+	SubscriptionVersion string `json:"subscription_version"`
 }
 
 // Key returns the key for storing in the registry

--- a/internal/nodebinding/model.go
+++ b/internal/nodebinding/model.go
@@ -14,9 +14,10 @@ const (
 // Model for a node
 type Model struct {
 	common.BaseModel
-	ID             string `json:"id"`
-	NodeID         string `json:"node_id"`
-	SubscriptionID string `json:"subscription_id"`
+	ID                    string `json:"id"`
+	NodeID                string `json:"node_id"`
+	SubscriptionID        string `json:"subscription_id"`
+	SubscriptionVersionID string `json:"subscription_version_id"`
 }
 
 // Key returns the key for storing in the registry

--- a/internal/nodebinding/repo.go
+++ b/internal/nodebinding/repo.go
@@ -44,7 +44,7 @@ func (r *Repo) List(ctx context.Context, prefix string) ([]common.IModel, error)
 		if err != nil {
 			return nil, err
 		}
-		m.SetVersionID(pair.VersionID)
+		m.SetVersion(pair.Version)
 		models = append(models, &m)
 	}
 	return models, nil

--- a/internal/nodebinding/repo.go
+++ b/internal/nodebinding/repo.go
@@ -44,6 +44,7 @@ func (r *Repo) List(ctx context.Context, prefix string) ([]common.IModel, error)
 		if err != nil {
 			return nil, err
 		}
+		m.SetVersionID(pair.VersionID)
 		models = append(models, &m)
 	}
 	return models, nil

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -40,9 +40,6 @@ func (s *Scheduler) Schedule(subscription *subscription.Model, nbs []*nodebindin
 		return nil, err
 	}
 	subVersion := subscription.GetVersion()
-	if err != nil {
-		return nil, err
-	}
 
 	nb := nodebinding.Model{
 		ID:                  uuid.New().String(),

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -39,16 +39,16 @@ func (s *Scheduler) Schedule(subscription *subscription.Model, nbs []*nodebindin
 	if err != nil {
 		return nil, err
 	}
-	svID, err := subscription.GetVersionID()
+	subVersion := subscription.GetVersion()
 	if err != nil {
 		return nil, err
 	}
 
 	nb := nodebinding.Model{
-		ID:                    uuid.New().String(),
-		NodeID:                node.ID,
-		SubscriptionID:        subscription.Name,
-		SubscriptionVersionID: svID,
+		ID:                  uuid.New().String(),
+		NodeID:              node.ID,
+		SubscriptionID:      subscription.Name,
+		SubscriptionVersion: subVersion,
 	}
 
 	return &nb, nil

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -39,11 +39,16 @@ func (s *Scheduler) Schedule(subscription *subscription.Model, nbs []*nodebindin
 	if err != nil {
 		return nil, err
 	}
+	svID, err := subscription.GetVersionID()
+	if err != nil {
+		return nil, err
+	}
 
 	nb := nodebinding.Model{
-		ID:             uuid.New().String(),
-		NodeID:         node.ID,
-		SubscriptionID: subscription.Name,
+		ID:                    uuid.New().String(),
+		NodeID:                node.ID,
+		SubscriptionID:        subscription.Name,
+		SubscriptionVersionID: svID,
 	}
 
 	return &nb, nil

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -40,6 +40,7 @@ func TestScheduler_Schedule(t *testing.T) {
 		sub := &subscription.Model{
 			Name: "sub2",
 		}
+		sub.SetVersionID("1")
 
 		nbs := []*nodebinding.Model{
 			{

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -40,7 +40,7 @@ func TestScheduler_Schedule(t *testing.T) {
 		sub := &subscription.Model{
 			Name: "sub2",
 		}
-		sub.SetVersionID("1")
+		sub.SetVersion("1")
 
 		nbs := []*nodebinding.Model{
 			{

--- a/internal/subscription/repo.go
+++ b/internal/subscription/repo.go
@@ -44,7 +44,7 @@ func (r *Repo) List(ctx context.Context, prefix string) ([]common.IModel, error)
 		if err != nil {
 			return nil, err
 		}
-		m.SetVersionID(pair.VersionID)
+		m.SetVersion(pair.Version)
 		models = append(models, &m)
 	}
 	return models, nil

--- a/internal/subscription/repo.go
+++ b/internal/subscription/repo.go
@@ -44,6 +44,7 @@ func (r *Repo) List(ctx context.Context, prefix string) ([]common.IModel, error)
 		if err != nil {
 			return nil, err
 		}
+		m.SetVersionID(pair.VersionID)
 		models = append(models, &m)
 	}
 	return models, nil

--- a/internal/tasks/schedulertask.go
+++ b/internal/tasks/schedulertask.go
@@ -203,7 +203,9 @@ func (sm *SchedulerTask) refreshNodeBindings(ctx context.Context) error {
 		return err
 	}
 
-	// Delete any binding where subscription is removed, This needs to be handled before nodes updates
+	// Delete any binding where subscription is removed or
+	// the subscription's current version id doesn't match the node binding's subscription version id.
+	// This needs to be handled before nodes updates
 	// as node update will cause subscriptions to be rescheduled on other nodes
 	var validBindings []*nodebinding.Model
 
@@ -211,9 +213,17 @@ func (sm *SchedulerTask) refreshNodeBindings(ctx context.Context) error {
 	for _, nb := range nodeBindings {
 		found := false
 		for _, sub := range sm.subCache {
+			sVID, verr := sub.GetVersionID()
+			if verr != nil {
+				return verr
+			}
 			if sub.Name == nb.SubscriptionID {
-				found = true
-				break
+				if nb.SubscriptionVersionID == sVID {
+					found = true
+					break
+				}
+				logger.Ctx(ctx).Infow("subscription updated, stale node binding will be deleted",
+					"subscription", sub.Name, "stale versionid", nb.SubscriptionVersionID, "new versionid", sVID)
 			}
 		}
 
@@ -269,15 +279,20 @@ func (sm *SchedulerTask) refreshNodeBindings(ctx context.Context) error {
 	// Create bindings for new subscriptions
 	for _, sub := range sm.subCache {
 		found := false
+		sVID, verr := sub.GetVersionID()
+		if verr != nil {
+			return verr
+		}
 		for _, nb := range nodeBindings {
-			if sub.Name == nb.SubscriptionID {
+			if sub.Name == nb.SubscriptionID && nb.SubscriptionVersionID == sVID {
 				found = true
 				break
 			}
 		}
 
 		if !found {
-			logger.Ctx(ctx).Infow("scheduling subscription on nodes", "subscription", sub.Name, "topic", sub.Topic)
+			logger.Ctx(ctx).Infow("scheduling subscription on nodes",
+				"subscription", sub.Name, "topic", sub.Topic, "subscription versionid", sVID)
 
 			topicM, terr := sm.topicCore.Get(ctx, sub.Topic)
 			if terr != nil {

--- a/internal/tasks/schedulertask.go
+++ b/internal/tasks/schedulertask.go
@@ -213,17 +213,14 @@ func (sm *SchedulerTask) refreshNodeBindings(ctx context.Context) error {
 	for _, nb := range nodeBindings {
 		found := false
 		for _, sub := range sm.subCache {
-			sVID, verr := sub.GetVersionID()
-			if verr != nil {
-				return verr
-			}
+			subVersion := sub.GetVersion()
 			if sub.Name == nb.SubscriptionID {
-				if nb.SubscriptionVersionID == sVID {
+				if nb.SubscriptionVersion == subVersion {
 					found = true
 					break
 				}
 				logger.Ctx(ctx).Infow("subscription updated, stale node binding will be deleted",
-					"subscription", sub.Name, "stale versionid", nb.SubscriptionVersionID, "new versionid", sVID)
+					"subscription", sub.Name, "stale version", nb.SubscriptionVersion, "new version", subVersion)
 			}
 		}
 
@@ -279,12 +276,9 @@ func (sm *SchedulerTask) refreshNodeBindings(ctx context.Context) error {
 	// Create bindings for new subscriptions
 	for _, sub := range sm.subCache {
 		found := false
-		sVID, verr := sub.GetVersionID()
-		if verr != nil {
-			return verr
-		}
+		subVersion := sub.GetVersion()
 		for _, nb := range nodeBindings {
-			if sub.Name == nb.SubscriptionID && nb.SubscriptionVersionID == sVID {
+			if sub.Name == nb.SubscriptionID && nb.SubscriptionVersion == subVersion {
 				found = true
 				break
 			}
@@ -292,7 +286,7 @@ func (sm *SchedulerTask) refreshNodeBindings(ctx context.Context) error {
 
 		if !found {
 			logger.Ctx(ctx).Infow("scheduling subscription on nodes",
-				"subscription", sub.Name, "topic", sub.Topic, "subscription versionid", sVID)
+				"subscription", sub.Name, "topic", sub.Topic, "subscription version", subVersion)
 
 			topicM, terr := sm.topicCore.Get(ctx, sub.Topic)
 			if terr != nil {

--- a/internal/tasks/schedulertask_test.go
+++ b/internal/tasks/schedulertask_test.go
@@ -76,6 +76,7 @@ func TestSchedulerTask_Run(t *testing.T) {
 			PushEndpoint: "http://test.test",
 		},
 	}
+	sub.SetVersionID("1")
 	subscriptionCoreMock.EXPECT().List(gomock.AssignableToTypeOf(ctx), "subscriptions/").Return(
 		[]*subscription.Model{&sub}, nil)
 
@@ -89,9 +90,10 @@ func TestSchedulerTask_Run(t *testing.T) {
 
 	// mock nodebindings core
 	nb := &nodebinding.Model{
-		ID:             uuid.New().String(),
-		NodeID:         workerID,
-		SubscriptionID: "projects/test-project/subscriptions/test",
+		ID:                    uuid.New().String(),
+		NodeID:                workerID,
+		SubscriptionID:        "projects/test-project/subscriptions/test",
+		SubscriptionVersionID: "1",
 	}
 
 	nodebindingCoreMock.EXPECT().List(gomock.AssignableToTypeOf(ctx), "nodebinding/").Return(

--- a/internal/tasks/schedulertask_test.go
+++ b/internal/tasks/schedulertask_test.go
@@ -76,7 +76,7 @@ func TestSchedulerTask_Run(t *testing.T) {
 			PushEndpoint: "http://test.test",
 		},
 	}
-	sub.SetVersionID("1")
+	sub.SetVersion("1")
 	subscriptionCoreMock.EXPECT().List(gomock.AssignableToTypeOf(ctx), "subscriptions/").Return(
 		[]*subscription.Model{&sub}, nil)
 
@@ -90,10 +90,10 @@ func TestSchedulerTask_Run(t *testing.T) {
 
 	// mock nodebindings core
 	nb := &nodebinding.Model{
-		ID:                    uuid.New().String(),
-		NodeID:                workerID,
-		SubscriptionID:        "projects/test-project/subscriptions/test",
-		SubscriptionVersionID: "1",
+		ID:                  uuid.New().String(),
+		NodeID:              workerID,
+		SubscriptionID:      "projects/test-project/subscriptions/test",
+		SubscriptionVersion: "1",
 	}
 
 	nodebindingCoreMock.EXPECT().List(gomock.AssignableToTypeOf(ctx), "nodebinding/").Return(

--- a/pkg/registry/consul.go
+++ b/pkg/registry/consul.go
@@ -262,7 +262,7 @@ func (c *ConsulClient) Get(ctx context.Context, key string) (*Pair, error) {
 	if kv == nil {
 		return nil, errors.New("key not found")
 	}
-	return &Pair{Key: key, Value: kv.Value, VersionID: strconv.FormatUint(kv.ModifyIndex, 10)}, nil
+	return &Pair{Key: key, Value: kv.Value, Version: strconv.FormatUint(kv.ModifyIndex, 10)}, nil
 }
 
 // List returns a slice of pairs for a key prefix
@@ -286,9 +286,9 @@ func (c *ConsulClient) List(ctx context.Context, prefix string) ([]Pair, error) 
 
 	for _, kv := range kvs {
 		pairs = append(pairs, Pair{
-			Key:       kv.Key,
-			Value:     kv.Value,
-			VersionID: strconv.FormatUint(kv.ModifyIndex, 10),
+			Key:     kv.Key,
+			Value:   kv.Value,
+			Version: strconv.FormatUint(kv.ModifyIndex, 10),
 		})
 	}
 

--- a/pkg/registry/consul.go
+++ b/pkg/registry/consul.go
@@ -2,6 +2,8 @@ package registry
 
 import (
 	"context"
+	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/hashicorp/consul/api"
@@ -205,7 +207,7 @@ func (c *ConsulClient) Watch(ctx context.Context, wh *WatchConfig) (IWatcher, er
 }
 
 // Put a key value pair
-func (c *ConsulClient) Put(ctx context.Context, key string, value []byte) error {
+func (c *ConsulClient) Put(ctx context.Context, key string, value []byte) (string, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "ConsulClient.Put")
 	defer span.Finish()
 
@@ -216,15 +218,23 @@ func (c *ConsulClient) Put(ctx context.Context, key string, value []byte) error 
 		registryOperationTimeTaken.WithLabelValues(env, "Put").Observe(time.Now().Sub(startTime).Seconds())
 	}()
 
-	_, err := c.client.KV().Put(&api.KVPair{
-		Key:   key,
-		Value: value,
-	}, nil)
-	return err
+	// Using transaction because a simple put does not fetch the modifyindex
+	putTxn := api.TxnOps{&api.TxnOp{KV: &api.KVTxnOp{Verb: api.KVSet, Key: key, Value: value}}}
+	ok, resp, _, err := c.client.Txn().Txn(putTxn, nil)
+	if !ok {
+		if err != nil {
+			return "", err
+		}
+		// There must be exactly 1 error
+		err = fmt.Errorf(resp.Errors[0].What)
+		return "", err
+	}
+
+	return strconv.FormatUint(resp.Results[0].KV.ModifyIndex, 10), err
 }
 
 // Get returns a value for a key
-func (c *ConsulClient) Get(ctx context.Context, key string) ([]byte, error) {
+func (c *ConsulClient) Get(ctx context.Context, key string) (Pair, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "ConsulClient.Get")
 	defer span.Finish()
 
@@ -237,12 +247,12 @@ func (c *ConsulClient) Get(ctx context.Context, key string) ([]byte, error) {
 
 	kv, _, err := c.client.KV().Get(key, nil)
 	if err != nil {
-		return nil, err
+		return Pair{}, err
 	}
 	if kv == nil {
-		return nil, errors.New("key not found")
+		return Pair{}, errors.New("key not found")
 	}
-	return kv.Value, nil
+	return Pair{Key: key, Value: kv.Value, VersionID: strconv.FormatUint(kv.ModifyIndex, 10)}, nil
 }
 
 // List returns a slice of pairs for a key prefix
@@ -266,8 +276,9 @@ func (c *ConsulClient) List(ctx context.Context, prefix string) ([]Pair, error) 
 
 	for _, kv := range kvs {
 		pairs = append(pairs, Pair{
-			Key:   kv.Key,
-			Value: kv.Value,
+			Key:       kv.Key,
+			Value:     kv.Value,
+			VersionID: strconv.FormatUint(kv.ModifyIndex, 10),
 		})
 	}
 

--- a/pkg/registry/consul_test.go
+++ b/pkg/registry/consul_test.go
@@ -411,7 +411,7 @@ func TestGetSuccess(t *testing.T) {
 	ctx := context.Background()
 	val, err := c.Get(ctx, "k1")
 	t.Log(val)
-	assert.Equal(t, &Pair{Key: "k1", Value: []byte("v1"), VersionID: "0", SessionID: ""}, val)
+	assert.Equal(t, &Pair{Key: "k1", Value: []byte("v1"), Version: "0", SessionID: ""}, val)
 	assert.Nil(t, err)
 }
 

--- a/pkg/registry/consul_test.go
+++ b/pkg/registry/consul_test.go
@@ -358,8 +358,9 @@ func TestReleaseSuccess(t *testing.T) {
 
 func TestPutSuccess(t *testing.T) {
 	mux := http.NewServeMux()
-	mux.HandleFunc("/v1/kv/k1", func(res http.ResponseWriter, req *http.Request) {
-		fmt.Fprint(res, "true")
+	mux.HandleFunc("/v1/txn", func(res http.ResponseWriter, req *http.Request) {
+		resBody := `{"Results":[{"KV":{"LockIndex":0,"Key":"k1","Flags":0,"Value":"","CreateIndex":1,"ModifyIndex":1}}],"Errors":[]}`
+		fmt.Fprint(res, resBody)
 	})
 
 	ts := httptest.NewServer(mux)
@@ -375,8 +376,9 @@ func TestPutSuccess(t *testing.T) {
 	assert.Nil(t, err)
 
 	ctx := context.Background()
-	err = c.Put(ctx, "k1", []byte("v1"))
+	vid, err := c.Put(ctx, "k1", []byte(""))
 	assert.Nil(t, err)
+	assert.Equal(t, "1", vid, "modify index not set")
 }
 
 func TestGetSuccess(t *testing.T) {
@@ -409,7 +411,7 @@ func TestGetSuccess(t *testing.T) {
 	ctx := context.Background()
 	val, err := c.Get(ctx, "k1")
 	t.Log(val)
-	assert.Equal(t, []byte("v1"), val)
+	assert.Equal(t, Pair{Key: "k1", Value: []byte("v1"), VersionID: "0", SessionID: ""}, val)
 	assert.Nil(t, err)
 }
 

--- a/pkg/registry/consul_test.go
+++ b/pkg/registry/consul_test.go
@@ -411,7 +411,7 @@ func TestGetSuccess(t *testing.T) {
 	ctx := context.Background()
 	val, err := c.Get(ctx, "k1")
 	t.Log(val)
-	assert.Equal(t, Pair{Key: "k1", Value: []byte("v1"), VersionID: "0", SessionID: ""}, val)
+	assert.Equal(t, &Pair{Key: "k1", Value: []byte("v1"), VersionID: "0", SessionID: ""}, val)
 	assert.Nil(t, err)
 }
 

--- a/pkg/registry/helper_test.go
+++ b/pkg/registry/helper_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestGetKeys(t *testing.T) {
-	res := GetKeys([]Pair{{"k1", []byte("v1"), "s1"}})
+	res := GetKeys([]Pair{{"k1", []byte("v1"), "v1", "s1"}})
 	assert.Equal(t, res, []string{"k1"})
 }
 
@@ -19,6 +19,6 @@ func TestGetKeysNilPairs(t *testing.T) {
 }
 
 func TestGetKeysMultiplePairs(t *testing.T) {
-	res := GetKeys([]Pair{{"k1", []byte("v1"), "s1"}, {"k2", []byte("v2"), "s2"}})
+	res := GetKeys([]Pair{{"k1", []byte("v1"), "v1", "s1"}, {"k2", []byte("v2"), "v1", "s2"}})
 	assert.Equal(t, res, []string{"k1", "k2"})
 }

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -15,7 +15,7 @@ type Pair struct {
 }
 
 func (pair *Pair) String() string {
-	return fmt.Sprintf("key: %s, value: %s, sessionID: %s, versionID:%s", pair.Key, string(pair.Value), pair.SessionID, pair.VersionID)
+	return fmt.Sprintf("key: %s, value: %s, sessionID: %s, versionID: %s", pair.Key, string(pair.Value), pair.SessionID, pair.VersionID)
 }
 
 // IRegistry implements a generic interface for service discovery

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -8,8 +8,10 @@ import (
 
 // Pair is the registry struct returned to watch handler
 type Pair struct {
-	Key       string
-	Value     []byte
+	Key   string
+	Value []byte
+	// VersionID - The version of the stored key-value pair
+	// Set by the registry, ModifyIndex in case of consul
 	VersionID string
 	SessionID string
 }
@@ -50,7 +52,7 @@ type IRegistry interface {
 	Put(ctx context.Context, key string, value []byte) (string, error)
 
 	// Get returns a value for a key
-	Get(ctx context.Context, key string) (Pair, error)
+	Get(ctx context.Context, key string) (*Pair, error)
 
 	// List returns a keys with matching key prefix
 	ListKeys(ctx context.Context, prefix string) ([]string, error)

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -10,11 +10,12 @@ import (
 type Pair struct {
 	Key       string
 	Value     []byte
+	VersionID string
 	SessionID string
 }
 
 func (pair *Pair) String() string {
-	return fmt.Sprintf("key: %s, value: %s, sessionID: %s", pair.Key, string(pair.Value), pair.SessionID)
+	return fmt.Sprintf("key: %s, value: %s, sessionID: %s, versionID:%s", pair.Key, string(pair.Value), pair.SessionID, pair.VersionID)
 }
 
 // IRegistry implements a generic interface for service discovery
@@ -46,10 +47,10 @@ type IRegistry interface {
 	Watch(ctx context.Context, wh *WatchConfig) (IWatcher, error)
 
 	// Put a key value pair
-	Put(ctx context.Context, key string, value []byte) error
+	Put(ctx context.Context, key string, value []byte) (string, error)
 
 	// Get returns a value for a key
-	Get(ctx context.Context, key string) ([]byte, error)
+	Get(ctx context.Context, key string) (Pair, error)
 
 	// List returns a keys with matching key prefix
 	ListKeys(ctx context.Context, prefix string) ([]string, error)

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -10,14 +10,14 @@ import (
 type Pair struct {
 	Key   string
 	Value []byte
-	// VersionID - The version of the stored key-value pair
+	// Version - The version of the stored key-value pair
 	// Set by the registry, ModifyIndex in case of consul
-	VersionID string
+	Version   string
 	SessionID string
 }
 
 func (pair *Pair) String() string {
-	return fmt.Sprintf("key: %s, value: %s, sessionID: %s, versionID: %s", pair.Key, string(pair.Value), pair.SessionID, pair.VersionID)
+	return fmt.Sprintf("key: %s, value: %s, sessionID: %s, version: %s", pair.Key, string(pair.Value), pair.SessionID, pair.Version)
 }
 
 // IRegistry implements a generic interface for service discovery

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -13,8 +13,8 @@ func TestPairToString(t *testing.T) {
 		Key:       "k1",
 		Value:     []byte("v1"),
 		SessionID: "s1",
-		VersionID: "v1",
+		Version:   "v1",
 	}
 
-	assert.Equal(t, pair.String(), "key: k1, value: v1, sessionID: s1, versionID: v1")
+	assert.Equal(t, pair.String(), "key: k1, value: v1, sessionID: s1, version: v1")
 }

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -13,7 +13,8 @@ func TestPairToString(t *testing.T) {
 		Key:       "k1",
 		Value:     []byte("v1"),
 		SessionID: "s1",
+		VersionID: "v1",
 	}
 
-	assert.Equal(t, pair.String(), "key: k1, value: v1, sessionID: s1")
+	assert.Equal(t, pair.String(), "key: k1, value: v1, sessionID: s1, versionID: v1")
 }


### PR DESCRIPTION
    --Modified the common base model and interface to add version setters and getters

    --Moved the implementation of consul PUT API from KV to transaction based to get the modify index on edits

    --Modified common repo methods to set and return version ids

    --Modified node,nodebinding and subscription repo to set the version id in models in get calls

    --Added subscription version in nodebinding model

    --Modified scheduler to set the subscription version id when creating nodebindings

    --Modified the refresh bindings method to delete nodebindings on stale subscriptions
       and create new ones for updated subscriptions

    --Modified registry interface to incorporate version id on read and write operations

    --Modified the consul registry implementation to provide the modifyindex as versionid

    --Fixed linting errors

    --Fixed broken unit tests
