### PR TITLE
fixes proto marshal for push on endpoint payload

### DIFF
--- a/internal/stream/stream_test.go
+++ b/internal/stream/stream_test.go
@@ -1,0 +1,49 @@
+// +build unit
+
+package stream
+
+import (
+	"github.com/golang/protobuf/jsonpb"
+	metrov1 "github.com/razorpay/metro/rpc/proto/v1"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"testing"
+	"time"
+)
+
+func Test_ProtoMarhshalUnMarshal(t *testing.T) {
+
+	const layout = "Jan 2, 2006 at 3:04pm (MST)"
+	tm, _ := time.Parse(layout, "Jan 1, 2021 at 12:05pm (IST)") // using fixed time for deterministic test results
+
+	originalReq := &metrov1.PushEndpointRequest{
+		Message: &metrov1.PubsubMessage{
+			Data: []byte("abc"),
+			Attributes: map[string]string{
+				"k1": "v1",
+				"k2": "v2",
+			},
+			MessageId:   "msg-1",
+			PublishTime: timestamppb.New(tm),
+			OrderingKey: "ok-1",
+		},
+		Subscription: "subs-1",
+	}
+
+	// marshal
+	reqBytes := getRequestBytes(originalReq)
+	reqAsString := reqBytes.String()
+	// match the string generated after proto marshalling
+	assert.Equal(t, reqAsString, "{\"message\":{\"data\":\"YWJj\",\"attributes\":{\"k1\":\"v1\",\"k2\":\"v2\"},\"messageId\":\"msg-1\",\"publishTime\":\"2021-01-01T06:35:00Z\",\"orderingKey\":\"ok-1\"},\"subscription\":\"subs-1\"}")
+
+	// unmarshal
+	currentReq := metrov1.PushEndpointRequest{}
+	jsonpb.Unmarshal(reqBytes, &currentReq)
+
+	assert.Equal(t, originalReq.Subscription, currentReq.Subscription)
+	assert.Equal(t, originalReq.Message.MessageId, currentReq.Message.MessageId)
+	assert.Equal(t, originalReq.Message.OrderingKey, currentReq.Message.OrderingKey)
+	assert.Equal(t, originalReq.Message.Data, currentReq.Message.Data)
+	assert.Equal(t, originalReq.Message.Attributes, currentReq.Message.Attributes)
+	assert.Equal(t, originalReq.Message.PublishTime, currentReq.Message.PublishTime)
+}

--- a/internal/stream/stream_test.go
+++ b/internal/stream/stream_test.go
@@ -14,8 +14,8 @@ import (
 
 func Test_ProtoMarhshalUnMarshal(t *testing.T) {
 
-	const layout = "Jan 2, 2006 at 3:04pm (MST)"
-	tm, _ := time.Parse(layout, "Jan 1, 2021 at 12:05pm (IST)") // using fixed time for deterministic test results
+	const layout = "Jan 2, 2006 3:04pm"
+	tm, _ := time.Parse(layout, "Jan 1, 2021 12:05pm") // using fixed time for deterministic test results
 
 	originalReq := &metrov1.PushEndpointRequest{
 		Message: &metrov1.PubsubMessage{
@@ -35,7 +35,7 @@ func Test_ProtoMarhshalUnMarshal(t *testing.T) {
 	reqBytes := getRequestBytes(originalReq)
 	reqAsString := reqBytes.String()
 	// match the string generated after proto marshalling
-	assert.Equal(t, reqAsString, "{\"message\":{\"data\":\"YWJj\",\"attributes\":{\"k1\":\"v1\",\"k2\":\"v2\"},\"messageId\":\"msg-1\",\"publishTime\":\"2021-01-01T06:35:00Z\",\"orderingKey\":\"ok-1\"},\"subscription\":\"subs-1\"}")
+	assert.Equal(t, reqAsString, "{\"message\":{\"data\":\"YWJj\",\"attributes\":{\"k1\":\"v1\",\"k2\":\"v2\"},\"messageId\":\"msg-1\",\"publishTime\":\"2021-01-01T12:05:00Z\",\"orderingKey\":\"ok-1\"},\"subscription\":\"subs-1\"}")
 
 	// unmarshal
 	currentReq := metrov1.PushEndpointRequest{}

--- a/internal/stream/stream_test.go
+++ b/internal/stream/stream_test.go
@@ -3,12 +3,13 @@
 package stream
 
 import (
+	"testing"
+	"time"
+
 	"github.com/golang/protobuf/jsonpb"
 	metrov1 "github.com/razorpay/metro/rpc/proto/v1"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/types/known/timestamppb"
-	"testing"
-	"time"
 )
 
 func Test_ProtoMarhshalUnMarshal(t *testing.T) {

--- a/service/web/publisherserver.go
+++ b/service/web/publisherserver.go
@@ -44,7 +44,7 @@ func (s publisherServer) Publish(ctx context.Context, req *metrov1.PublishReques
 	if err != nil {
 		return nil, merror.ToGRPCError(err)
 	}
-	logger.Ctx(ctx).Infow("produce request completed", "req", req.Topic)
+	logger.Ctx(ctx).Infow("produce request completed", "req", req.Topic, "message_ids", msgIDs)
 	return &metrov1.PublishResponse{MessageIds: msgIDs}, nil
 }
 


### PR DESCRIPTION
- Fixed response format:

`{
  "message": {
    "messageId": "c49bkhd94816v5c9an7g",
    "publishTime": "2021-08-10T17:41:27Z"
  },
  "subscription": "projects/dummy-1/subscriptions/subs15"
}`

- nit: Logging msg_ids on publish complete