### PR TITLE
toggle socket.keepalive.enable

### DIFF
--- a/pkg/messagebroker/kafka.go
+++ b/pkg/messagebroker/kafka.go
@@ -50,11 +50,12 @@ func newKafkaConsumerClient(ctx context.Context, bConfig *BrokerConfig, options 
 	}
 
 	configMap := &kafkapkg.ConfigMap{
-		"bootstrap.servers":  strings.Join(bConfig.Brokers, ","),
-		"auto.offset.reset":  "latest",
-		"enable.auto.commit": false,
-		"group.id":           options.GroupID,
-		"group.instance.id":  options.GroupInstanceID,
+		"bootstrap.servers":       strings.Join(bConfig.Brokers, ","),
+		"socket.keepalive.enable": true,
+		"auto.offset.reset":       "latest",
+		"enable.auto.commit":      false,
+		"group.id":                options.GroupID,
+		"group.instance.id":       options.GroupInstanceID,
 	}
 
 	logger.Ctx(ctx).Infow("kafka consumer: initializing new", "configMap", configMap, "options", options)
@@ -103,7 +104,13 @@ func newKafkaProducerClient(ctx context.Context, bConfig *BrokerConfig, options 
 	logger.Ctx(ctx).Infow("kafka producer: initializing new", "options", options)
 
 	configMap := &kafkapkg.ConfigMap{
-		"bootstrap.servers": strings.Join(bConfig.Brokers, ","),
+		"bootstrap.servers":       strings.Join(bConfig.Brokers, ","),
+		"socket.keepalive.enable": true,
+		"retries":                 2,
+		"linger.ms":               0,
+		"request.timeout.ms":      30000,
+		"delivery.timeout.ms":     150000,
+		"connections.max.idle.ms": 180000,
 	}
 
 	if bConfig.EnableTLS {


### PR DESCRIPTION
[Recommended](https://docs.microsoft.com/en-us/azure/event-hubs/apache-kafka-configurations#producer-and-consumer-configurations-1) to set this to true  if the connection is expected to idle