### PR TITLE
Moved Subscription Push Config Auth to separate authentication field

### DIFF
--- a/internal/subscription/proto.go
+++ b/internal/subscription/proto.go
@@ -21,11 +21,12 @@ func ModelToSubscriptionProtoV1(m *Model) *metrov1.Subscription {
 			Attributes:   m.PushConfig.Attributes,
 		}
 		if m.PushConfig.Credentials != nil {
-			if proto.PushConfig.Attributes == nil {
-				proto.PushConfig.Attributes = map[string]string{}
+			proto.PushConfig.AuthenticationMethod = &metrov1.PushConfig_BasicAuth_{
+				BasicAuth: &metrov1.PushConfig_BasicAuth{
+					Username: m.PushConfig.Credentials.GetUsername(),
+					Password: m.PushConfig.Credentials.GetPassword(),
+				},
 			}
-			proto.PushConfig.Attributes[attributeUsername] = m.PushConfig.Credentials.GetUsername()
-			proto.PushConfig.Attributes[attributePassword] = m.PushConfig.Credentials.GetPassword()
 		}
 	}
 

--- a/internal/subscription/proto_test.go
+++ b/internal/subscription/proto_test.go
@@ -28,9 +28,11 @@ func Test_ModelToSubscriptionProtoV1(t *testing.T) {
 		Name:  "projects/project123/subscriptions/subscription123",
 		Topic: "projects/project123/topics/topic123",
 		PushConfig: &metrov1.PushConfig{
-			Attributes: map[string]string{
-				"username": "user",
-				"password": pwd,
+			AuthenticationMethod: &metrov1.PushConfig_BasicAuth_{
+				BasicAuth: &metrov1.PushConfig_BasicAuth{
+					Username: "user",
+					Password: pwd,
+				},
 			},
 			PushEndpoint: "https://www.razorpay.com/api",
 		},


### PR DESCRIPTION
With this change, authentication details for push subscription will be sent via a separate auth field in push_config instead of sending them in attributes. 

Sample push subscription request with basic auth

```
{
    "topic": "sample_topic",
    "ackDeadlineSeconds": 100,
    "push_config": {
        "push_endpoint": "https://webhook.site/a6c76f08-316d-4fe3-a168-3486e9dd153e",
        "basic_auth": {
            "username": "abc",
            "password": "password"
        }
    }
}
```