### PR TITLE
Issue #249: Fix worker panics

### DIFF
--- a/internal/brokerstore/brokerstore.go
+++ b/internal/brokerstore/brokerstore.go
@@ -154,10 +154,10 @@ func (b *BrokerStore) RemoveConsumer(ctx context.Context, op messagebroker.Consu
 	b.partitionLock.Lock(key.String())         // lock
 	defer b.partitionLock.Unlock(key.String()) // unlock
 
-	consumer, ok := b.consumerMap.Load(key.String())
+	_, ok := b.consumerMap.Load(key.String())
 	if ok {
 		wasConsumerFound = true
-		b.consumerMap.Delete(consumer)
+		b.consumerMap.Delete(key.String())
 		brokerStoreActiveConsumersCount.WithLabelValues(env, key.String()).Dec()
 	}
 
@@ -241,7 +241,7 @@ func (b *BrokerStore) RemoveProducer(ctx context.Context, op messagebroker.Produ
 	producer, ok := b.producerMap.Load(key.String())
 	if ok && producer != nil {
 		wasProducerFound = true
-		b.producerMap.Delete(producer)
+		b.producerMap.Delete(key.String())
 		producer.(messagebroker.Producer).Shutdown(ctx)
 		// init a new producer after removal so that a non-nil producer is available on subsequent calls
 		b.GetProducer(ctx, op)

--- a/internal/subscriber/core.go
+++ b/internal/subscriber/core.go
@@ -60,6 +60,7 @@ func (c *Core) NewSubscriber(ctx context.Context,
 			WithBackoff(retry.NewExponentialWindowBackoff()).
 			WithIntervalFinder(retry.NewClosestIntervalWithCeil()).
 			WithMessageHandler(retry.NewPushToPrimaryRetryTopicHandler(c.bs)).
+			WithSubscriberID(subscriberID).
 			Build()
 
 		err = retrier.Start(subsCtx)

--- a/internal/subscriber/retry/builder.go
+++ b/internal/subscriber/retry/builder.go
@@ -14,6 +14,7 @@ type Builder interface {
 	WithBrokerStore(store brokerstore.IBrokerStore) Builder
 	WithSubscription(subs *subscription.Model) Builder
 	WithMessageHandler(handler MessageHandler) Builder
+	WithSubscriberID(subscriberID string) Builder
 	Build() IRetrier
 }
 
@@ -54,5 +55,11 @@ func (retrier *Retrier) WithSubscription(subs *subscription.Model) Builder {
 // WithMessageHandler ...
 func (retrier *Retrier) WithMessageHandler(handler MessageHandler) Builder {
 	retrier.handler = handler
+	return retrier
+}
+
+// WithSubscriberID ...
+func (retrier *Retrier) WithSubscriberID(subscriberID string) Builder {
+	retrier.subscriberID = subscriberID
 	return retrier
 }

--- a/internal/subscriber/retry/delayconsumer.go
+++ b/internal/subscriber/retry/delayconsumer.go
@@ -11,26 +11,27 @@ import (
 
 // DelayConsumer ...
 type DelayConsumer struct {
-	ctx        context.Context
-	cancelFunc func()
-	doneCh     chan struct{}
-	subs       *subscription.Model
-	topic      string
-	isPaused   bool
-	consumer   messagebroker.Consumer
-	bs         brokerstore.IBrokerStore
-	handler    MessageHandler
+	subscriberID string
+	ctx          context.Context
+	cancelFunc   func()
+	doneCh       chan struct{}
+	subs         *subscription.Model
+	topic        string
+	isPaused     bool
+	consumer     messagebroker.Consumer
+	bs           brokerstore.IBrokerStore
+	handler      MessageHandler
 	// a paused consumer will not return new messages, so this cachedMsg will be used for lookups
 	// till the needed time elapses
 	cachedMsg *messagebroker.ReceivedMessage
 }
 
 // NewDelayConsumer inits a new delay-consumer with the pre-defined message handler
-func NewDelayConsumer(ctx context.Context, topic string, subs *subscription.Model, bs brokerstore.IBrokerStore, handler MessageHandler) (*DelayConsumer, error) {
+func NewDelayConsumer(ctx context.Context, subscriberID string, topic string, subs *subscription.Model, bs brokerstore.IBrokerStore, handler MessageHandler) (*DelayConsumer, error) {
 
 	delayCtx, cancel := context.WithCancel(ctx)
 	// only delay-consumer will consume from a subscription specific delay-topic, so can use the same groupID and groupInstanceID
-	consumerOps := messagebroker.ConsumerClientOptions{Topics: []string{topic}, GroupID: subs.GetDelayConsumerGroupID(topic), GroupInstanceID: subs.GetDelayConsumerGroupInstanceID(topic)}
+	consumerOps := messagebroker.ConsumerClientOptions{Topics: []string{topic}, GroupID: subs.GetDelayConsumerGroupID(topic), GroupInstanceID: subs.GetDelayConsumerGroupInstanceID(subscriberID, topic)}
 	consumer, err := bs.GetConsumer(ctx, consumerOps)
 	if err != nil {
 		logger.Ctx(ctx).Errorw("delay-consumer: failed to create consumer", "error", err.Error())
@@ -41,14 +42,15 @@ func NewDelayConsumer(ctx context.Context, topic string, subs *subscription.Mode
 	consumer.Resume(ctx, messagebroker.ResumeOnTopicRequest{Topic: topic})
 
 	return &DelayConsumer{
-		ctx:        delayCtx,
-		cancelFunc: cancel,
-		topic:      topic,
-		consumer:   consumer,
-		subs:       subs,
-		bs:         bs,
-		handler:    handler,
-		doneCh:     make(chan struct{}),
+		subscriberID: subscriberID,
+		ctx:          delayCtx,
+		cancelFunc:   cancel,
+		topic:        topic,
+		consumer:     consumer,
+		subs:         subs,
+		bs:           bs,
+		handler:      handler,
+		doneCh:       make(chan struct{}),
 	}, nil
 }
 
@@ -61,7 +63,7 @@ func (dc *DelayConsumer) Run(ctx context.Context) {
 		select {
 		case <-dc.ctx.Done():
 			logger.Ctx(dc.ctx).Infow("delay-consumer: stopping <-ctx.Done() called", dc.LogFields()...)
-			dc.bs.RemoveConsumer(ctx, messagebroker.ConsumerClientOptions{GroupID: dc.subs.GetDelayConsumerGroupID(dc.topic), GroupInstanceID: dc.subs.GetDelayConsumerGroupInstanceID(dc.topic)})
+			dc.bs.RemoveConsumer(ctx, messagebroker.ConsumerClientOptions{GroupID: dc.subs.GetDelayConsumerGroupID(dc.topic), GroupInstanceID: dc.subs.GetDelayConsumerGroupInstanceID(dc.subscriberID, dc.topic)})
 			dc.consumer.Close(dc.ctx)
 			return
 		default:
@@ -177,7 +179,7 @@ func (dc *DelayConsumer) LogFields(kv ...interface{}) []interface{} {
 		"delayConsumerConfig", map[string]interface{}{
 			"topic":           dc.topic,
 			"groupID":         dc.subs.GetDelayConsumerGroupID(dc.topic),
-			"groupInstanceID": dc.subs.GetDelayConsumerGroupInstanceID(dc.topic),
+			"groupInstanceID": dc.subs.GetDelayConsumerGroupInstanceID(dc.subscriberID, dc.topic),
 		},
 	}
 

--- a/internal/subscriber/retry/delayconsumer_test.go
+++ b/internal/subscriber/retry/delayconsumer_test.go
@@ -49,12 +49,13 @@ func TestDelayConsumer_Run(t *testing.T) {
 			},
 		},
 	}
+	subscriberID := "subscriber-id"
 
 	mockBrokerStore.EXPECT().GetConsumer(gomock.Any(), gomock.Any()).Return(mockConsumer, nil)
 	mockConsumer.EXPECT().Resume(gomock.AssignableToTypeOf(ctx), gomock.Any()).Return(nil).AnyTimes()
 
 	// initialize delay consumer
-	dc, err := NewDelayConsumer(ctx, "t1", subs, mockBrokerStore, mockHandler)
+	dc, err := NewDelayConsumer(ctx, subscriberID, "t1", subs, mockBrokerStore, mockHandler)
 	assert.NotNil(t, dc)
 	assert.Nil(t, err)
 	assert.NotNil(t, dc.LogFields())

--- a/internal/subscriber/retry/retrier.go
+++ b/internal/subscriber/retry/retrier.go
@@ -24,6 +24,7 @@ type IRetrier interface {
 
 // Retrier implements all business logic for IRetrier
 type Retrier struct {
+	subscriberID   string
 	subs           *subscription.Model
 	bs             brokerstore.IBrokerStore
 	backoff        Backoff
@@ -36,7 +37,7 @@ type Retrier struct {
 func (r *Retrier) Start(ctx context.Context) error {
 	// TODO : validate retrier params for nils and substitute with defaults
 	for interval, topic := range r.subs.GetDelayTopicsMap() {
-		dc, err := NewDelayConsumer(ctx, topic, r.subs, r.bs, r.handler)
+		dc, err := NewDelayConsumer(ctx, r.subscriberID, topic, r.subs, r.bs, r.handler)
 		if err != nil {
 			return err
 		}

--- a/internal/subscription/delay.go
+++ b/internal/subscription/delay.go
@@ -9,8 +9,8 @@ const delayTopicWithProjectNameFormat = "projects/%v/topics/%v.delay.%v.seconds"
 // subs.delay.30.seconds-cg
 const delayConsumerGroupIDFormat = "%v-cg"
 
-// subs.delay.30.seconds-cgi
-const delayConsumerGroupInstanceIDFormat = "%v-cgi"
+// delayTopicName-subscriberID
+const delayConsumerGroupInstanceIDFormat = "%v-%v"
 
 // Interval is internal delay type per allowed interval
 type Interval uint

--- a/internal/subscription/model.go
+++ b/internal/subscription/model.go
@@ -196,6 +196,6 @@ func (m *Model) GetDelayConsumerGroupID(delayTopic string) string {
 }
 
 // GetDelayConsumerGroupInstanceID returns the consumer group ID to be used by the specific delay consumer
-func (m *Model) GetDelayConsumerGroupInstanceID(delayTopic string) string {
-	return fmt.Sprintf(delayConsumerGroupInstanceIDFormat, delayTopic)
+func (m *Model) GetDelayConsumerGroupInstanceID(subscriberID, delayTopic string) string {
+	return fmt.Sprintf(delayConsumerGroupInstanceIDFormat, delayTopic, subscriberID)
 }

--- a/internal/subscription/model_test.go
+++ b/internal/subscription/model_test.go
@@ -78,5 +78,5 @@ func Test_Model(t *testing.T) {
 	assert.Equal(t, []string{"projects/test-project/topics/test-subscription.delay.5.seconds", "projects/test-project/topics/test-subscription.delay.30.seconds", "projects/test-project/topics/test-subscription.delay.60.seconds", "projects/test-project/topics/test-subscription.delay.150.seconds", "projects/test-project/topics/test-subscription.delay.300.seconds", "projects/test-project/topics/test-subscription.delay.600.seconds", "projects/test-project/topics/test-subscription.delay.1800.seconds", "projects/test-project/topics/test-subscription.delay.3600.seconds"}, delayTopics)
 
 	assert.Equal(t, "test-subscription.delay.5.seconds-cg", dSubscription.GetDelayConsumerGroupID("test-subscription.delay.5.seconds"))
-	assert.Equal(t, "test-subscription.delay.5.seconds-cgi", dSubscription.GetDelayConsumerGroupInstanceID("test-subscription.delay.5.seconds"))
+	assert.Equal(t, "test-subscription.delay.5.seconds-subscriberID", dSubscription.GetDelayConsumerGroupInstanceID("subscriberID", "test-subscription.delay.5.seconds"))
 }


### PR DESCRIPTION
  -- Fixed the remove producer, remove consumer bug of calling delete with val instead of key
  -- Added the subscriber id as prefix for delay consumer group-instance-id to isolate multiple consumers of topic
  -- Wrote test cases