### PR TITLE
Issue #221:  Added Admin APIs for Fetching and Listing Project Credentials

### DIFF
--- a/internal/credentials/core.go
+++ b/internal/credentials/core.go
@@ -120,7 +120,7 @@ func (c *Core) List(ctx context.Context, projectID string) ([]*Model, error) {
 		credentialOperationTimeTaken.WithLabelValues(env, "List").Observe(time.Now().Sub(startTime).Seconds())
 	}()
 
-	prefix := common.GetBasePrefix() + Prefix + projectID
+	prefix := common.GetBasePrefix() + Prefix + projectID + "/"
 
 	var out []*Model
 	ret, err := c.repo.List(ctx, prefix)

--- a/internal/credentials/core_test.go
+++ b/internal/credentials/core_test.go
@@ -76,7 +76,7 @@ func TestCore_List_Success(t *testing.T) {
 	ctx := context.Background()
 
 	project := "project123"
-	prefix := common.GetBasePrefix() + Prefix + project
+	prefix := common.GetBasePrefix() + Prefix + project + "/"
 
 	var model common.IModel = &Model{
 		Username:  "user1",
@@ -106,7 +106,7 @@ func TestCore_List_Failure(t *testing.T) {
 	ctx := context.Background()
 
 	project := "project123"
-	prefix := common.GetBasePrefix() + Prefix + project
+	prefix := common.GetBasePrefix() + Prefix + project + "/"
 
 	mockRepo.EXPECT().List(ctx, prefix).Return(nil, errors.New("Error getting credentials"))
 

--- a/internal/credentials/core_test.go
+++ b/internal/credentials/core_test.go
@@ -66,3 +66,19 @@ func TestCore_Get(t *testing.T) {
 	_, err := c.Get(ctx, project, username)
 	assert.NoError(t, err)
 }
+
+func TestCore_List(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockRepo := mocks1.NewMockIRepo(ctrl)
+	mockCore := mocks2.NewMockICore(ctrl)
+	c := NewCore(mockRepo, mockCore)
+	ctx := context.Background()
+
+	project := "project123"
+	prefix := common.GetBasePrefix() + Prefix + project
+
+	mockRepo.EXPECT().List(ctx, prefix).Return(nil, nil)
+
+	_, err := c.List(ctx, project)
+	assert.NoError(t, err)
+}

--- a/internal/credentials/core_test.go
+++ b/internal/credentials/core_test.go
@@ -4,6 +4,7 @@ package credentials
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/razorpay/metro/internal/common"
@@ -67,7 +68,7 @@ func TestCore_Get(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestCore_List(t *testing.T) {
+func TestCore_List_Success(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockRepo := mocks1.NewMockIRepo(ctrl)
 	mockCore := mocks2.NewMockICore(ctrl)
@@ -77,8 +78,39 @@ func TestCore_List(t *testing.T) {
 	project := "project123"
 	prefix := common.GetBasePrefix() + Prefix + project
 
-	mockRepo.EXPECT().List(ctx, prefix).Return(nil, nil)
+	var model common.IModel = &Model{
+		Username:  "user1",
+		Password:  "pass1",
+		ProjectID: "project123",
+	}
 
-	_, err := c.List(ctx, project)
+	expectedOut := []*Model{{
+		Username:  "user1",
+		Password:  "pass1",
+		ProjectID: "project123",
+	}}
+
+	models := []common.IModel{model}
+	mockRepo.EXPECT().List(ctx, prefix).Return(models, nil)
+
+	out, err := c.List(ctx, project)
 	assert.NoError(t, err)
+	assert.Equal(t, expectedOut, out)
+}
+
+func TestCore_List_Failure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockRepo := mocks1.NewMockIRepo(ctrl)
+	mockCore := mocks2.NewMockICore(ctrl)
+	c := NewCore(mockRepo, mockCore)
+	ctx := context.Background()
+
+	project := "project123"
+	prefix := common.GetBasePrefix() + Prefix + project
+
+	mockRepo.EXPECT().List(ctx, prefix).Return(nil, errors.New("Error getting credentials"))
+
+	out, err := c.List(ctx, project)
+	assert.Error(t, err, "Error getting credentials")
+	assert.Nil(t, out)
 }

--- a/internal/credentials/model.go
+++ b/internal/credentials/model.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
+	"github.com/pkg/errors"
 	"github.com/razorpay/metro/internal/common"
 	"github.com/razorpay/metro/pkg/encryption"
 	"github.com/sethvargo/go-password/password"
@@ -27,6 +28,9 @@ const (
 var (
 	// CtxKey identified credentials will be populated in ctx with this key
 	CtxKey = contextKey("CredentialsCtxKey")
+
+	// ErrPasswordNotInExpectedFormat ...
+	ErrPasswordNotInExpectedFormat = errors.New("Password not in expected format")
 )
 
 type contextKey string
@@ -88,11 +92,15 @@ func (m *Model) GetPassword() string {
 // GetHiddenPassword returns the Password after
 // masking all but last 4 characters with *
 // warning: make sure length of password is >= 4
-func (m *Model) GetHiddenPassword() string {
+func (m *Model) GetHiddenPassword() (string, error) {
 	// Returns a hidden password which contains a string of asterisk
 	// followed by last 4 characters of the original password
 	password := m.GetPassword()
-	return AsteriskString + password[len(password)-4:]
+
+	if len(password) < 4 {
+		return "", ErrPasswordNotInExpectedFormat
+	}
+	return AsteriskString + password[len(password)-4:], nil
 }
 
 // GetProjectID returns the credential projectID

--- a/internal/credentials/model.go
+++ b/internal/credentials/model.go
@@ -38,7 +38,8 @@ func (c contextKey) String() string {
 // Model for a credential
 type Model struct {
 	common.BaseModel
-	Username  string `json:"username"`
+	Username string `json:"username"`
+	// warning: Password must be of length >= 4
 	Password  string `json:"password"`
 	ProjectID string `json:"project_id"`
 	// in future, this model can contain some ACL as well
@@ -86,6 +87,7 @@ func (m *Model) GetPassword() string {
 
 // GetHiddenPassword returns the Password after
 // masking all but last 4 characters with *
+// warning: make sure length of password is >= 4
 func (m *Model) GetHiddenPassword() string {
 	// Returns a hidden password which contains a string of asterisk
 	// followed by last 4 characters of the original password

--- a/internal/credentials/model.go
+++ b/internal/credentials/model.go
@@ -89,7 +89,8 @@ func (m *Model) GetPassword() string {
 func (m *Model) GetHiddenPassword() string {
 	// Returns a hidden password which contains a string of asterisk
 	// followed by last 4 characters of the original password
-	return AsteriskString + m.GetPassword()[len(m.GetPassword())-4:len(m.GetPassword())]
+	password := m.GetPassword()
+	return AsteriskString + password[len(password)-4:]
 }
 
 // GetProjectID returns the credential projectID

--- a/internal/credentials/model.go
+++ b/internal/credentials/model.go
@@ -19,6 +19,9 @@ const (
 
 	// perf10__656f81 : sample username format
 	usernameFormat = "%v%v%v"
+
+	// AsteriskString used to return a masked password
+	AsteriskString = "********"
 )
 
 var (
@@ -79,6 +82,14 @@ func (m *Model) GetPassword() string {
 	// decrypt before reading Password
 	pwd, _ := encryption.DecryptFromHexString(m.Password)
 	return string(pwd)
+}
+
+// GetHiddenPassword returns the Password after
+// masking all but last 4 characters with *
+func (m *Model) GetHiddenPassword() string {
+	// Returns a hidden password which contains a string of asterisk
+	// followed by last 4 characters of the original password
+	return AsteriskString + m.GetPassword()[len(m.GetPassword())-4:len(m.GetPassword())]
 }
 
 // GetProjectID returns the credential projectID

--- a/internal/credentials/model_test.go
+++ b/internal/credentials/model_test.go
@@ -33,5 +33,15 @@ func getDummyCredentials() *Model {
 func TestModel_HiddenPassword(t *testing.T) {
 	credentials := getDummyCredentials()
 	expectedHiddenPassword := AsteriskString + "word"
-	assert.Equal(t, expectedHiddenPassword, credentials.GetHiddenPassword())
+	hiddenPwd, err := credentials.GetHiddenPassword()
+	assert.Nil(t, err)
+	assert.Equal(t, expectedHiddenPassword, hiddenPwd)
+}
+
+func TestModel_HiddenPassword_Failure(t *testing.T) {
+	credentials := getDummyCredentials()
+	credentials.Password = "SHo5MThKVTQ2NjVYMGg5dllvRjk="
+	hiddenPwd, err := credentials.GetHiddenPassword()
+	assert.Empty(t, hiddenPwd)
+	assert.Equal(t, err, ErrPasswordNotInExpectedFormat)
 }

--- a/internal/credentials/model_test.go
+++ b/internal/credentials/model_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/razorpay/metro/internal/common"
+	"github.com/razorpay/metro/pkg/encryption"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -20,9 +21,17 @@ func TestModel_Key(t *testing.T) {
 }
 
 func getDummyCredentials() *Model {
+	encryption.RegisterEncryptionKey("key")
+	pwd, _ := encryption.EncryptAsHexString([]byte("password"))
 	return &Model{
 		Username:  "project123__c525c7",
-		Password:  "l0laNoI360l4uvD96682",
+		Password:  pwd,
 		ProjectID: "project123",
 	}
+}
+
+func TestModel_HiddenPassword(t *testing.T) {
+	credentials := getDummyCredentials()
+	expectedHiddenPassword := AsteriskString + "word"
+	assert.Equal(t, expectedHiddenPassword, credentials.GetHiddenPassword())
 }

--- a/internal/credentials/repo.go
+++ b/internal/credentials/repo.go
@@ -1,6 +1,10 @@
 package credentials
 
 import (
+	"context"
+	"encoding/json"
+
+	"github.com/opentracing/opentracing-go"
 	"github.com/razorpay/metro/internal/common"
 	"github.com/razorpay/metro/pkg/registry"
 )
@@ -8,6 +12,7 @@ import (
 // IRepo interface over database repository
 type IRepo interface {
 	common.IRepo
+	List(ctx context.Context, prefix string) ([]common.IModel, error)
 }
 
 // Repo implements various repository methods
@@ -20,4 +25,27 @@ func NewRepo(registry registry.IRegistry) IRepo {
 	return &Repo{
 		common.BaseRepo{Registry: registry},
 	}
+}
+
+// List returns a slice of credentials matching prefix
+func (r *Repo) List(ctx context.Context, prefix string) ([]common.IModel, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "CredentialsRepository.List")
+	defer span.Finish()
+
+	pairs, err := r.Registry.List(ctx, prefix)
+	if err != nil {
+		return nil, err
+	}
+
+	models := []common.IModel{}
+	for _, pair := range pairs {
+		var m Model
+		err = json.Unmarshal(pair.Value, &m)
+		if err != nil {
+			return nil, err
+		}
+		m.SetVersion(pair.Version)
+		models = append(models, &m)
+	}
+	return models, nil
 }

--- a/service/web/adminserver.go
+++ b/service/web/adminserver.go
@@ -203,14 +203,19 @@ func (s adminServer) ListProjectCredentials(ctx context.Context, req *metrov1.Pr
 		return nil, merror.ToGRPCError(err)
 	}
 
-	logger.Ctx(ctx).Infow("request to fetch credentials completed", "projectID", req.ProjectId, "username", req.Username)
+	logger.Ctx(ctx).Infow("request to list credentials completed", "projectID", req.ProjectId)
 
 	var credentials []*metrov1.ProjectCredentials
 	for _, m := range models {
+		hiddenPwd, err := m.GetHiddenPassword()
+		if err != nil {
+			logger.Ctx(ctx).Errorw("error occurred in masking credentials", "errMsg", err.Error(), "projectID", m.ProjectID, "username", m.Username)
+			continue
+		}
 		credentials = append(credentials, &metrov1.ProjectCredentials{
 			ProjectId: m.ProjectID,
 			Username:  m.GetUsername(),
-			Password:  m.GetHiddenPassword(),
+			Password:  hiddenPwd,
 		})
 	}
 	return &metrov1.ProjectCredentialsList{

--- a/service/web/adminserver.go
+++ b/service/web/adminserver.go
@@ -172,6 +172,52 @@ func (s adminServer) DeleteProjectCredentials(ctx context.Context, req *metrov1.
 	return &emptypb.Empty{}, nil
 }
 
+// fetch and return the ProjectCredentials for the given projectId and username
+func (s adminServer) FetchProjectCredentials(ctx context.Context, req *metrov1.ProjectCredentials) (*metrov1.ProjectCredentials, error) {
+	logger.Ctx(ctx).Infow("received request to fetch project credentials", "projectID", req.ProjectId, "username", req.Username)
+
+	credential, err := s.credentialCore.Get(ctx, req.ProjectId, req.Username)
+
+	if err != nil {
+		return nil, merror.ToGRPCError(err)
+	}
+
+	logger.Ctx(ctx).Infow("request to fetch credentials completed", "projectID", req.ProjectId, "username", req.Username)
+
+	return &metrov1.ProjectCredentials{
+		ProjectId: credential.ProjectID,
+		Username:  credential.GetUsername(),
+		Password:  credential.GetPassword(),
+	}, nil
+}
+
+// returns list of all the project credentials for the given projectId
+func (s adminServer) ListProjectCredentials(ctx context.Context, req *metrov1.ProjectCredentials) (*metrov1.ProjectCredentialsList, error) {
+	logger.Ctx(ctx).Infow("received request to list project credentials", "projectID", req.ProjectId)
+
+	projectID := req.ProjectId
+
+	models, err := s.credentialCore.List(ctx, projectID)
+
+	if err != nil {
+		return nil, merror.ToGRPCError(err)
+	}
+
+	logger.Ctx(ctx).Infow("request to fetch credentials completed", "projectID", req.ProjectId, "username", req.Username)
+
+	var credentials []*metrov1.ProjectCredentials
+	for _, m := range models {
+		credentials = append(credentials, &metrov1.ProjectCredentials{
+			ProjectId: m.ProjectID,
+			Username:  m.GetUsername(),
+			Password:  m.GetHiddenPassword(),
+		})
+	}
+	return &metrov1.ProjectCredentialsList{
+		ProjectCredentials: credentials,
+	}, nil
+}
+
 func (s adminServer) MigrateSubscriptions(ctx context.Context, subscriptions *metrov1.Subscriptions) (*emptypb.Empty, error) {
 	logger.Ctx(ctx).Infow("received request to migrate subscriptions", "subscriptions", subscriptions.GetNames())
 

--- a/service/web/adminserver.go
+++ b/service/web/adminserver.go
@@ -172,9 +172,9 @@ func (s adminServer) DeleteProjectCredentials(ctx context.Context, req *metrov1.
 	return &emptypb.Empty{}, nil
 }
 
-// fetch and return the ProjectCredentials for the given projectId and username
-func (s adminServer) FetchProjectCredentials(ctx context.Context, req *metrov1.ProjectCredentials) (*metrov1.ProjectCredentials, error) {
-	logger.Ctx(ctx).Infow("received request to fetch project credentials", "projectID", req.ProjectId, "username", req.Username)
+// get the ProjectCredentials for the given projectId and username
+func (s adminServer) GetProjectCredentials(ctx context.Context, req *metrov1.ProjectCredentials) (*metrov1.ProjectCredentials, error) {
+	logger.Ctx(ctx).Infow("received request to get project credentials", "projectID", req.ProjectId, "username", req.Username)
 
 	credential, err := s.credentialCore.Get(ctx, req.ProjectId, req.Username)
 
@@ -182,7 +182,7 @@ func (s adminServer) FetchProjectCredentials(ctx context.Context, req *metrov1.P
 		return nil, merror.ToGRPCError(err)
 	}
 
-	logger.Ctx(ctx).Infow("request to fetch credentials completed", "projectID", req.ProjectId, "username", req.Username)
+	logger.Ctx(ctx).Infow("request to get credentials completed", "projectID", req.ProjectId, "username", req.Username)
 
 	return &metrov1.ProjectCredentials{
 		ProjectId: credential.ProjectID,

--- a/service/web/adminserver_test.go
+++ b/service/web/adminserver_test.go
@@ -155,7 +155,7 @@ func TestAdminServer_DeleteProjectValidationFailure(t *testing.T) {
 	assert.Nil(t, p)
 }
 
-func TestAdminServer_FetchProjectCredentials(t *testing.T) {
+func TestAdminServer_GetProjectCredentials(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockProjectCore := mocks.NewMockICore(ctrl)
 	mockSubscriptionCore := mocks2.NewMockICore(ctrl)
@@ -193,7 +193,7 @@ func TestAdminServer_FetchProjectCredentials(t *testing.T) {
 	mockCredentialsCore.EXPECT().
 		Get(ctx, projectCredProto.ProjectId, projectCredProto.Username).Times(1).
 		Return(credential, nil)
-	p, err := adminServer.FetchProjectCredentials(ctx, projectCredProto)
+	p, err := adminServer.GetProjectCredentials(ctx, projectCredProto)
 	assert.Nil(t, err)
 	assert.Equal(t, expectedCredProto, p)
 }

--- a/service/web/adminserver_test.go
+++ b/service/web/adminserver_test.go
@@ -181,7 +181,7 @@ func TestAdminServer_FetchProjectCredentials(t *testing.T) {
 		Password:  pwd,
 	}
 
-	exectedCredProto := &metrov1.ProjectCredentials{
+	expectedCredProto := &metrov1.ProjectCredentials{
 		ProjectId: "test-project",
 		Username:  "test-project__00f790",
 		Password:  "password",
@@ -195,7 +195,7 @@ func TestAdminServer_FetchProjectCredentials(t *testing.T) {
 		Return(credential, nil)
 	p, err := adminServer.FetchProjectCredentials(ctx, projectCredProto)
 	assert.Nil(t, err)
-	assert.Equal(t, exectedCredProto, p)
+	assert.Equal(t, expectedCredProto, p)
 }
 
 func TestAdminServer_ListProjectCredentials(t *testing.T) {
@@ -224,7 +224,7 @@ func TestAdminServer_ListProjectCredentials(t *testing.T) {
 		Password:  pwd,
 	}}
 
-	exectedCredProto := &metrov1.ProjectCredentialsList{
+	expectedCredProto := &metrov1.ProjectCredentialsList{
 		ProjectCredentials: []*metrov1.ProjectCredentials{{
 			ProjectId: "test-project",
 			Username:  "test-project__00f790",
@@ -240,5 +240,5 @@ func TestAdminServer_ListProjectCredentials(t *testing.T) {
 		Return(credential, nil)
 	p, err := adminServer.ListProjectCredentials(ctx, projectCredProto)
 	assert.Nil(t, err)
-	assert.Equal(t, exectedCredProto, p)
+	assert.Equal(t, expectedCredProto, p)
 }

--- a/service/web/adminserver_test.go
+++ b/service/web/adminserver_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/razorpay/metro/internal/credentials"
+	"github.com/razorpay/metro/pkg/encryption"
 
 	"google.golang.org/protobuf/types/known/emptypb"
 
@@ -152,4 +153,92 @@ func TestAdminServer_DeleteProjectValidationFailure(t *testing.T) {
 	p, err := adminServer.DeleteProject(ctx, projectProto)
 	assert.NotNil(t, err)
 	assert.Nil(t, p)
+}
+
+func TestAdminServer_FetchProjectCredentials(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockProjectCore := mocks.NewMockICore(ctrl)
+	mockSubscriptionCore := mocks2.NewMockICore(ctrl)
+	mockTopicCore := mocks3.NewMockICore(ctrl)
+	mockCredentialsCore := mocks4.NewMockICore(ctrl)
+
+	projectCredProto := &metrov1.ProjectCredentials{
+		ProjectId: "test-project",
+		Username:  "test-project__00f790",
+	}
+
+	encryption.RegisterEncryptionKey("key")
+	pwd, _ := encryption.EncryptAsHexString([]byte("password"))
+
+	admin := &credentials.Model{
+		Username: "u",
+		Password: "p",
+	}
+
+	credential := &credentials.Model{
+		ProjectID: "test-project",
+		Username:  "test-project__00f790",
+		Password:  pwd,
+	}
+
+	exectedCredProto := &metrov1.ProjectCredentials{
+		ProjectId: "test-project",
+		Username:  "test-project__00f790",
+		Password:  "password",
+	}
+
+	adminServer := newAdminServer(admin, mockProjectCore, mockSubscriptionCore, mockTopicCore, mockCredentialsCore, nil)
+	ctx := context.Background()
+
+	mockCredentialsCore.EXPECT().
+		Get(ctx, projectCredProto.ProjectId, projectCredProto.Username).Times(1).
+		Return(credential, nil)
+	p, err := adminServer.FetchProjectCredentials(ctx, projectCredProto)
+	assert.Nil(t, err)
+	assert.Equal(t, exectedCredProto, p)
+}
+
+func TestAdminServer_ListProjectCredentials(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockProjectCore := mocks.NewMockICore(ctrl)
+	mockSubscriptionCore := mocks2.NewMockICore(ctrl)
+	mockTopicCore := mocks3.NewMockICore(ctrl)
+	mockCredentialsCore := mocks4.NewMockICore(ctrl)
+
+	projectCredProto := &metrov1.ProjectCredentials{
+		ProjectId: "test-project",
+		Username:  "test-project__00f790",
+	}
+
+	encryption.RegisterEncryptionKey("key")
+	pwd, _ := encryption.EncryptAsHexString([]byte("password"))
+
+	admin := &credentials.Model{
+		Username: "u",
+		Password: "p",
+	}
+
+	credential := []*credentials.Model{{
+		ProjectID: "test-project",
+		Username:  "test-project__00f790",
+		Password:  pwd,
+	}}
+
+	exectedCredProto := &metrov1.ProjectCredentialsList{
+		ProjectCredentials: []*metrov1.ProjectCredentials{{
+			ProjectId: "test-project",
+			Username:  "test-project__00f790",
+			Password:  credentials.AsteriskString + "word",
+		}},
+	}
+
+	adminServer := newAdminServer(admin, mockProjectCore, mockSubscriptionCore, mockTopicCore, mockCredentialsCore, nil)
+	ctx := context.Background()
+
+	mockCredentialsCore.EXPECT().
+		List(ctx, projectCredProto.ProjectId).Times(1).
+		Return(credential, nil)
+	p, err := adminServer.ListProjectCredentials(ctx, projectCredProto)
+	assert.Nil(t, err)
+	assert.Equal(t, exectedCredProto, p)
 }


### PR DESCRIPTION
- Added Fetch ProjectCredentials API in admin route which can be used to get lost credentials using projectId and username.
- Also added List ProjectCredentials API which will list out all the credentials for the given projectId. Note that password in this output will be masked.