### PR TITLE
Feature/admin dashboard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,11 +95,11 @@ buf-deps:
 proto-generate:
 	@echo "\n + Generating pb language bindings\n"
 	@buf generate --path ./metro-proto/metro/proto
-	# Generate static assets for OpenAPI UI
+	# Substitute {param=...} path params into {param} to solve swagger substitution problem
 	@sed -E "s/\{([a-zA-Z0-9\.]+)=[^\}]+\}/{\1}/g" third_party/OpenAPI/proto/v1/spec.swagger.json > third_party/OpenAPI/proto/v1/spec.swagger.json.tmp
 	@rm third_party/OpenAPI/proto/v1/spec.swagger.json
 	@mv third_party/OpenAPI/proto/v1/spec.swagger.json.tmp third_party/OpenAPI/proto/v1/spec.swagger.json
-	@cat third_party/OpenAPI/proto/v1/spec.swagger.json
+	# Generate static assets for OpenAPI UI
 	@statik -m -f -src third_party/OpenAPI/proto/v1
 
 .PHONY: proto-clean ## Clean generated proto files

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,11 @@ proto-generate:
 	@echo "\n + Generating pb language bindings\n"
 	@buf generate --path ./metro-proto/metro/proto
 	# Generate static assets for OpenAPI UI
-	@statik -m -f -src third_party/OpenAPI/
+	@sed -E "s/\{([a-zA-Z0-9\.]+)=[^\}]+\}/{\1}/g" third_party/OpenAPI/proto/v1/spec.swagger.json > third_party/OpenAPI/proto/v1/spec.swagger.json.tmp
+	@rm third_party/OpenAPI/proto/v1/spec.swagger.json
+	@mv third_party/OpenAPI/proto/v1/spec.swagger.json.tmp third_party/OpenAPI/proto/v1/spec.swagger.json
+	@cat third_party/OpenAPI/proto/v1/spec.swagger.json
+	@statik -m -f -src third_party/OpenAPI/proto/v1
 
 .PHONY: proto-clean ## Clean generated proto files
 proto-clean:

--- a/service/openapi-server/config.go
+++ b/service/openapi-server/config.go
@@ -4,4 +4,5 @@ package openapiserver
 type Config struct {
 	HTTPServerAddress  string
 	GRPCGatewayAddress string
+	Scheme             string
 }

--- a/service/openapi-server/service.go
+++ b/service/openapi-server/service.go
@@ -50,7 +50,7 @@ func (svc *Service) runOpenAPIHandler(ctx context.Context) error {
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasPrefix(r.RequestURI, metroAPIPrefix) {
 			httputil.NewSingleHostReverseProxy(&url.URL{
-				Scheme: "http",
+				Scheme: svc.config.Scheme,
 				Host:   svc.config.GRPCGatewayAddress,
 			}).ServeHTTP(w, r)
 		} else {


### PR DESCRIPTION
- Fixed swagger path param substitution
- Removed the cat command from makefile written while debugging

The API calls made by Swagger UI are defined by `spec.swagger.json` which is generated on running `buf generate --path ./metro-proto/metro/proto` through the `make proto-generate` command. The definitions of Swagger APIs are controlled by our proto definitions, google.api.http annotations and open-api annotations in `spec.proto` file.

Currently, the generated swagger spec contains URLs such as `/v1/{name=projects/*/topics/*}` with the path parameter named `name`. This creates a problem since swagger does not substitute the param because of the string mismatch bewtween `{name=projects/*/topics/*}` and `name`. 

The only non-hacky way of solving this problem would be to rename our API definitions like `/v1/projects/{project}/topics/{topic}`. But this would have a cascading effect in terms of refactoring our code. We would have to change most of the controller implementations and also the authorization logic.

This PR provides a hacky solution by using `sed`. We replace `/v1/{name=projects/*/topics/*}` with `/v1/{name}`. This solves the swagger problem.