### PR TITLE
Added filter support in create subscription

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	cloud.google.com/go v0.84.0 // indirect
 	cloud.google.com/go/pubsub v1.11.0
 	github.com/HdrHistogram/hdrhistogram-go v1.1.0 // indirect
+	github.com/alecthomas/participle/v2 v2.0.0-alpha7
 	github.com/apache/pulsar-client-go v0.5.0
 	github.com/apache/pulsar-client-go/oauth2 v0.0.0-20210615012709-cb72395fb53f // indirect
 	github.com/armon/go-metrics v0.3.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,10 @@ github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAE
 github.com/Shopify/goreferrer v0.0.0-20181106222321-ec9c9a553398/go.mod h1:a1uqRtAwp2Xwc6WNPJEufxJ7fx3npB4UV/JOLmbu5I0=
 github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
+github.com/alecthomas/participle/v2 v2.0.0-alpha7 h1:cK4vjj0VSgb3lN1nuKA5F7dw+1s1pWBe5bx7nNCnN+c=
+github.com/alecthomas/participle/v2 v2.0.0-alpha7/go.mod h1:NumScqsC42o9x+dGj8/YqsIfhrIQjFEOFovxotbBirA=
+github.com/alecthomas/repr v0.0.0-20181024024818-d37bc2a10ba1 h1:GDQdwm/gAcJcLAKQQZGOJ4knlw+7rfEQQcmwTbt4p5E=
+github.com/alecthomas/repr v0.0.0-20181024024818-d37bc2a10ba1/go.mod h1:xTS7Pm1pD1mvyM075QCDSRqH6qRLXylzS24ZTpRiSzQ=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=

--- a/internal/subscription/model.go
+++ b/internal/subscription/model.go
@@ -27,7 +27,7 @@ type Model struct {
 	EnableMessageOrdering          bool              `json:"enable_message_ordering,omitempty"`
 	ExpirationPolicy               *ExpirationPolicy `json:"expiration_policy,omitempty"`
 	FilterExpression               string            `json:"filter,omitempty"`
-	FilterStruct                   *Filter           `json:"filter_struct,omitempty"`
+	filterStruct                   *Filter
 	RetryPolicy                    *RetryPolicy      `json:"retry_policy,omitempty"`
 	DeadLetterPolicy               *DeadLetterPolicy `json:"dead_letter_policy,omitempty"`
 	Detached                       bool              `json:"detached,omitempty"`
@@ -203,4 +203,18 @@ func (m *Model) GetDelayConsumerGroupID(delayTopic string) string {
 // GetDelayConsumerGroupInstanceID returns the consumer group ID to be used by the specific delay consumer
 func (m *Model) GetDelayConsumerGroupInstanceID(subscriberID, delayTopic string) string {
 	return fmt.Sprintf(delayConsumerGroupInstanceIDFormat, delayTopic, subscriberID)
+}
+
+// GetFilterExpressionAsStruct parses and returns the filter expression into GO Struct
+func (m *Model) GetFilterExpressionAsStruct() (*Filter, error) {
+	if m.filterStruct != nil {
+		return m.filterStruct, nil
+	}
+	f := &Filter{}
+	err := filter.Parser.ParseString("", m.FilterExpression, f)
+	if err != nil {
+		return nil, err
+	}
+	m.filterStruct = f
+	return f, nil
 }

--- a/internal/subscription/model.go
+++ b/internal/subscription/model.go
@@ -6,6 +6,7 @@ import (
 	"github.com/razorpay/metro/internal/common"
 	"github.com/razorpay/metro/internal/credentials"
 	"github.com/razorpay/metro/internal/topic"
+	filter "github.com/razorpay/metro/pkg/filtering"
 )
 
 const (
@@ -25,7 +26,8 @@ type Model struct {
 	Labels                         map[string]string `json:"labels,omitempty"`
 	EnableMessageOrdering          bool              `json:"enable_message_ordering,omitempty"`
 	ExpirationPolicy               *ExpirationPolicy `json:"expiration_policy,omitempty"`
-	Filter                         string            `json:"filter,omitempty"`
+	FilterExpression               string            `json:"filter,omitempty"`
+	FilterStruct                   *Filter           `json:"filter_struct,omitempty"`
 	RetryPolicy                    *RetryPolicy      `json:"retry_policy,omitempty"`
 	DeadLetterPolicy               *DeadLetterPolicy `json:"dead_letter_policy,omitempty"`
 	Detached                       bool              `json:"detached,omitempty"`
@@ -34,6 +36,9 @@ type Model struct {
 	ExtractedTopicName             string            `json:"extracted_topic_name"`
 	ExtractedSubscriptionName      string            `json:"extracted_subscription_name"`
 }
+
+// Filter defines the Filter criteria for messages
+type Filter = filter.Condition
 
 // PushConfig defines the push endpoint
 type PushConfig struct {

--- a/internal/subscription/validation.go
+++ b/internal/subscription/validation.go
@@ -12,7 +12,6 @@ import (
 	"github.com/razorpay/metro/internal/credentials"
 	"github.com/razorpay/metro/internal/merror"
 	"github.com/razorpay/metro/internal/topic"
-	filter "github.com/razorpay/metro/pkg/filtering"
 	metrov1 "github.com/razorpay/metro/rpc/proto/v1"
 )
 
@@ -194,16 +193,14 @@ func validateSubscriptionName(ctx context.Context, m *Model, req *metrov1.Subscr
 
 func validateFilterExpression(ctx context.Context, m *Model, req *metrov1.Subscription) error {
 	if req.Filter != "" {
+		m.FilterExpression = req.Filter
+
 		// validate that the filter expression is in the expected format.
-		// Also convert the expression into a GO Struct
-		f := &Filter{}
-		err := filter.Parser.ParseString(m.Name, req.Filter, f)
+		// To validate, we convert it into a GO Struct with the defined Grammar in Struct Tags
+		_, err := m.GetFilterExpressionAsStruct()
 		if err != nil {
 			return err
 		}
-
-		m.FilterExpression = req.Filter
-		m.FilterStruct = f
 	}
 	return nil
 }

--- a/pkg/filtering/as-filter.go
+++ b/pkg/filtering/as-filter.go
@@ -1,0 +1,175 @@
+// Copyright (c) 2021 6 River Systems
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package filter
+
+import (
+	"fmt"
+	"strconv"
+	"unicode"
+)
+
+// Writer is a subset of strings.Builder
+type Writer interface {
+	WriteString(string) (int, error)
+	WriteRune(rune) (int, error)
+}
+
+type AsFilter interface {
+	AsFilter(Writer) error
+}
+
+func (e *Condition) AsFilter(w Writer) (err error) {
+	if err = e.Term.AsFilter(w); err != nil {
+		return
+	}
+	switch {
+	case e.And != nil:
+		return appendTerms(w, OpAND, e.And)
+	case e.Or != nil:
+		return appendTerms(w, OpOR, e.Or)
+	default:
+		return
+	}
+}
+
+func appendTerms(w Writer, op BooleanOperator, terms []*term) error {
+	if len(terms) == 0 {
+		return fmt.Errorf("filter: unpopulated %s sequence", op)
+	}
+	for _, ee := range terms {
+		if _, err := w.WriteRune(' '); err != nil {
+			return err
+		}
+		if _, err := w.WriteString(string(op)); err != nil {
+			return err
+		}
+		if _, err := w.WriteRune(' '); err != nil {
+			return err
+		}
+		if err := ee.AsFilter(w); err != nil {
+			return fmt.Errorf("filter: error in %s sequence Term: %w", op, err)
+		}
+	}
+	return nil
+}
+
+func (e *term) AsFilter(w Writer) error {
+	if e.Not {
+		if _, err := w.WriteString("NOT "); err != nil {
+			return err
+		}
+	}
+	switch {
+	case e.Basic != nil:
+		if err := e.Basic.AsFilter(w); err != nil {
+			return err
+		}
+	case e.Sub != nil:
+		if _, err := w.WriteRune('('); err != nil {
+			return err
+		}
+		if err := e.Sub.AsFilter(w); err != nil {
+			return err
+		}
+		if _, err := w.WriteRune(')'); err != nil {
+			return err
+		}
+	default:
+		return ErrUnpopulatedTerm
+	}
+	return nil
+}
+
+func (e *basicExpression) AsFilter(w Writer) error {
+	switch {
+	case e.Has != nil:
+		return e.Has.AsFilter(w)
+	case e.Value != nil:
+		return e.Value.AsFilter(w)
+	case e.Predicate != nil:
+		return e.Predicate.AsFilter(w)
+	default:
+		return ErrUnpopulatedBasicExpression
+	}
+}
+
+func (e *hasAttribute) AsFilter(w Writer) error {
+	if _, err := w.WriteString("attributes:"); err != nil {
+		return err
+	}
+	if _, err := w.WriteString(formatAttrName(e.Name)); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (e *hasAttributeValue) AsFilter(w Writer) error {
+	if _, err := w.WriteString("attributes."); err != nil {
+		return err
+	}
+	if _, err := w.WriteString(formatAttrName(e.Name)); err != nil {
+		return err
+	}
+	if _, err := w.WriteString(string(e.Op)); err != nil {
+		return err
+	}
+	if _, err := w.WriteString(strconv.Quote(e.Value)); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (e *hasAttributePredicate) AsFilter(w Writer) error {
+	if _, err := w.WriteString(string(e.Predicate)); err != nil {
+		return err
+	}
+	if _, err := w.WriteString("(attributes."); err != nil {
+		return err
+	}
+	if _, err := w.WriteString(formatAttrName(e.Name)); err != nil {
+		return err
+	}
+	if _, err := w.WriteRune(','); err != nil {
+		return err
+	}
+	if _, err := w.WriteString(strconv.Quote(e.Value)); err != nil {
+		return err
+	}
+	if _, err := w.WriteRune(')'); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Add Identation and quotes for attribute name
+func formatAttrName(name string) string {
+	isIdent := true
+	for i, ch := range name {
+		if !(ch == '_' || unicode.IsLetter(ch) || unicode.IsDigit(ch) && i > 0) {
+			isIdent = false
+			break
+		}
+	}
+	if isIdent {
+		return name
+	} else {
+		return strconv.Quote(name)
+	}
+}

--- a/pkg/filtering/evaluate.go
+++ b/pkg/filtering/evaluate.go
@@ -1,0 +1,138 @@
+// Copyright (c) 2021 6 River Systems
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package filter
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// Evaluator interface which all grammar components should implement
+type Evaluator interface {
+	Evaluate(attrs map[string]string) (bool, error)
+}
+
+// Evaluate implementation for Basic Expression
+func (e *basicExpression) Evaluate(attrs map[string]string) (bool, error) {
+	switch {
+	case e.Has != nil:
+		return e.Has.Evaluate(attrs)
+	case e.Value != nil:
+		return e.Value.Evaluate(attrs)
+	case e.Predicate != nil:
+		return e.Predicate.Evaluate(attrs)
+	default:
+		return false, errors.New("unpopulated BasicExpression")
+	}
+}
+
+// Evaluate implementation for Condition
+func (e *Condition) Evaluate(attrs map[string]string) (result bool, err error) {
+	result, err = e.Term.Evaluate(attrs)
+	if err != nil {
+		return
+	}
+	switch {
+	case e.And != nil:
+		if result {
+			result, err = andTerms(attrs, e.And)
+		}
+	case e.Or != nil:
+		if !result {
+			result, err = orTerms(attrs, e.Or)
+		}
+	}
+	return
+}
+
+// Evaluate implementation for Term
+func (e *term) Evaluate(attrs map[string]string) (result bool, err error) {
+	switch {
+	case e.Basic != nil:
+		result, err = e.Basic.Evaluate(attrs)
+	case e.Sub != nil:
+		result, err = e.Sub.Evaluate(attrs)
+	default:
+		return false, errors.New("unpopulated Term")
+	}
+	result = result != e.Not // XOR
+	return result, err
+}
+
+// Evaluate implementation for HasAttribute
+func (e *hasAttribute) Evaluate(attrs map[string]string) (bool, error) {
+	_, ok := attrs[e.Name]
+	return ok, nil
+}
+
+// Evaluate implementation for HasAttributeValue
+func (e *hasAttributeValue) Evaluate(attrs map[string]string) (bool, error) {
+	v, ok := attrs[e.Name]
+	if !ok {
+		return false, nil
+	}
+	switch e.Op {
+	case opEqual:
+		return v == e.Value, nil
+	case opNotEqual:
+		return v != e.Value, nil
+	default:
+		return false, fmt.Errorf("invalid Op '%s'", e.Op)
+	}
+}
+
+// Evaluate implementation for HasAttributePredicate
+func (e *hasAttributePredicate) Evaluate(attrs map[string]string) (bool, error) {
+	v, ok := attrs[e.Name]
+	if !ok {
+		return false, nil
+	}
+	switch e.Predicate {
+	case predicateHasPrefix:
+		return strings.HasPrefix(v, e.Value), nil
+	default:
+		return false, fmt.Errorf("invalid predicate '%s'", e.Predicate)
+	}
+}
+
+func andTerms(attrs map[string]string, terms []*term) (result bool, err error) {
+	if len(terms) == 0 {
+		return false, errors.New("AND requires a non-empty term list")
+	}
+	for _, t := range terms {
+		if result, err = t.Evaluate(attrs); err != nil || !result {
+			return
+		}
+	}
+	return
+}
+
+func orTerms(attrs map[string]string, terms []*term) (result bool, err error) {
+	if len(terms) == 0 {
+		return false, errors.New("OR requires a non-empty term list")
+	}
+	for _, t := range terms {
+		if result, err = t.Evaluate(attrs); err != nil || result {
+			return
+		}
+	}
+	return
+}

--- a/pkg/filtering/grammar.go
+++ b/pkg/filtering/grammar.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2021 6 River Systems
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package filter
+
+// Condition contains term or multiple terms with 'AND' or 'OR' logical operator
+type Condition struct {
+	Term *term   `parser:"@@" json:"term,omitempty"`
+	And  []*term `parser:"( (\"AND\" @@ )+" json:"and,omitempty"`
+	Or   []*term `parser:"| (\"OR\" @@)+ )?" json:"or,omitempty"`
+}
+
+// term can be a Basic Expression or a Sub-Condition. It can also have 'NOT' boolean operator
+type term struct {
+	Not   bool             `parser:"@(\"NOT\"|\"-\")?" json:"NOT,omitempty"`
+	Basic *basicExpression `parser:"( @@" json:"basic,omitempty"`
+	Sub   *Condition       `parser:"| \"(\" @@ \")\" )" json:"sub,omitempty"`
+}
+
+// Basic Expression can be of any of the below types:
+// 1. HasAttribute: If the given attribute is present
+// 2. HasAttributeValue: If the given attribute is present with a give value
+// 3. HasAttributePredicate: If the given attribute is present with the given predicate
+type basicExpression struct {
+	Has       *hasAttribute          `parser:"@@" json:"hasAttribute,omitempty"`
+	Value     *hasAttributeValue     `parser:"| @@" json:"hasAttributeValue,omitempty"`
+	Predicate *hasAttributePredicate `parser:"| @@" json:"hasAttributePredicate,omitempty"`
+}
+
+type hasAttribute struct {
+	Name string `parser:"\"attributes\" \":\" @(Ident|String)" json:"name,omitempty"`
+}
+
+type hasAttributeValue struct {
+	Name  string            `parser:"\"attributes\" \".\" @(Ident|String)" json:"name,omitempty"`
+	Op    attributeOperator `parser:"@(\"=\" | \"!\" \"=\")" json:"operator,omitempty"`
+	Value string            `parser:"@String" json:"value,omitempty"`
+}
+
+// hasAttributePredicate ..
+// Supported Predicates : prefix
+type hasAttributePredicate struct {
+	Predicate attributePredicate `parser:"@(\"hasPrefix\")\"(\"" json:"predicate,omitempty"`
+	Name      string             `parser:"\"attributes\" \".\" @(Ident|String) \",\"" json:"name,omitempty"`
+	Value     string             `parser:"@String \")\"" json:"value,omitempty"`
+}
+
+type attributeOperator string
+
+const (
+	opEqual    attributeOperator = "="
+	opNotEqual attributeOperator = "!="
+)
+
+type attributePredicate string
+
+const (
+	predicateHasPrefix attributePredicate = "hasPrefix"
+)

--- a/pkg/filtering/grammar.go
+++ b/pkg/filtering/grammar.go
@@ -19,6 +19,12 @@
 
 package filter
 
+// Filter Expressions will be mapped to the below defined
+// Condition struct according to the logic provided using GO Struct Tags
+// Example:
+// "attributes:'language_tag' AND (attributes.domain = 'net' OR attributes.domain = 'org')"
+// "attributes:'language_tag' AND NOT attributes.size = 'XL' AND hasPrefix(attributes.domain, 'co')"
+
 // Condition contains term or multiple terms with 'AND' or 'OR' logical operator
 type Condition struct {
 	Term *term   `parser:"@@" json:"term,omitempty"`
@@ -72,4 +78,11 @@ type attributePredicate string
 
 const (
 	predicateHasPrefix attributePredicate = "hasPrefix"
+)
+
+type BooleanOperator string
+
+const (
+	OpAND BooleanOperator = "AND"
+	OpOR  BooleanOperator = "OR"
 )

--- a/pkg/filtering/grammar.go
+++ b/pkg/filtering/grammar.go
@@ -80,9 +80,9 @@ const (
 	predicateHasPrefix attributePredicate = "hasPrefix"
 )
 
-type BooleanOperator string
+type booleanOperator string
 
 const (
-	OpAND BooleanOperator = "AND"
-	OpOR  BooleanOperator = "OR"
+	opAND booleanOperator = "AND"
+	opOR  booleanOperator = "OR"
 )

--- a/pkg/filtering/parser.go
+++ b/pkg/filtering/parser.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2021 6 River Systems
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package filter
+
+import (
+	"github.com/alecthomas/participle/v2"
+)
+
+var defaultParserOptions = []participle.Option{
+	participle.UseLookahead(50),
+	// attribute values (or prefixes) need to be unquoted
+	participle.Unquote("String"),
+}
+
+// Parser will be used to parse Filter Expression into defined Go Structs.
+var Parser = participle.MustBuild(
+	&Condition{},
+	defaultParserOptions...,
+)

--- a/pkg/filtering/parser.go
+++ b/pkg/filtering/parser.go
@@ -24,7 +24,6 @@ import (
 )
 
 var defaultParserOptions = []participle.Option{
-	participle.UseLookahead(50),
 	// attribute values (or prefixes) need to be unquoted
 	participle.Unquote("String"),
 }


### PR DESCRIPTION
- This PR contains the changes for supporting the filtering capability while creating the subscription.
- Using filter expression, subscribers can filter messages by their attributes. 
- Separate PR/Revision will be raised which will include the logic of using the filter details to evaluate the incoming messages and filter out relevant messages to be sent to the subscriber. 
- For each message that is sent to the topic, it's message attributes will be used to call the evaluation function for the subscription filter and will be sent to the subscriber only if matches the requirements. 
