### PR TITLE
Ingestion prep:  subscription backfill endpoint

### DIFF
--- a/internal/subscription/model.go
+++ b/internal/subscription/model.go
@@ -81,6 +81,11 @@ func (m *Model) GetTopic() string {
 	return m.Topic
 }
 
+// GetSubscriptionTopic returns the topic used for subscription fanout topic
+func (m *Model) GetSubscriptionTopic() string {
+	return topic.GetTopicName(m.ExtractedTopicProjectID, m.ExtractedSubscriptionName)
+}
+
 // GetRetryTopic returns the topic used for subscription retries
 func (m *Model) GetRetryTopic() string {
 	return topic.GetTopicName(m.ExtractedTopicProjectID, m.ExtractedSubscriptionName+topic.RetryTopicSuffix)

--- a/internal/subscription/model_test.go
+++ b/internal/subscription/model_test.go
@@ -1,3 +1,4 @@
+//go:build unit
 // +build unit
 
 package subscription
@@ -51,6 +52,7 @@ func Test_Model(t *testing.T) {
 
 	assert.True(t, dSubscription.IsPush())
 	assert.Equal(t, "projects/test-project/topics/test-topic", dSubscription.GetTopic())
+	assert.Equal(t, "projects/test-project/topics/test-subscription", dSubscription.GetSubscriptionTopic())
 	assert.Equal(t, "projects/test-project/topics/test-subscription-retry", dSubscription.GetRetryTopic())
 	assert.Equal(t, "projects/test-project/topics/test-subscription-dlq", dSubscription.GetDeadLetterTopic())
 

--- a/internal/topic/core.go
+++ b/internal/topic/core.go
@@ -22,6 +22,7 @@ type ICore interface {
 	DeleteTopic(ctx context.Context, m *Model) error
 	DeleteProjectTopics(ctx context.Context, projectID string) error
 	Get(ctx context.Context, key string) (*Model, error)
+	CreateSubscriptionTopic(ctx context.Context, model *Model) error
 	CreateRetryTopic(ctx context.Context, model *Model) error
 	CreateDeadLetterTopic(ctx context.Context, model *Model) error
 }
@@ -76,6 +77,12 @@ func (c *Core) CreateTopic(ctx context.Context, m *Model) error {
 
 	// create registry entry
 	return c.repo.Save(ctx, m)
+}
+
+// CreateSubscriptionTopic creates a subscription topic for the given primary topic and name
+func (c *Core) CreateSubscriptionTopic(ctx context.Context, model *Model) error {
+	// create topic for fanout
+	return c.createBrokerTopic(ctx, model)
 }
 
 // CreateRetryTopic creates a retry topic for the given primary topic and name


### PR DESCRIPTION
- [x] Modifies the migration endpoint to create the subscription broker topics.
- [x] Create subscription broker topics when a new subscription is created.