### PR TITLE
Setup subscriptions only if a topic exists

### DIFF
--- a/internal/tasks/schedulertask.go
+++ b/internal/tasks/schedulertask.go
@@ -309,8 +309,6 @@ func (sm *SchedulerTask) refreshNodeBindings(ctx context.Context) error {
 			if terr != nil {
 				logger.Ctx(ctx).Errorw("Failed to fetch topic for subscription",
 					"subscription", sub.Name, "topic", sub.Topic, "subscription version", subVersion)
-				//return terr
-				continue
 			} else {
 				for i := 0; i < topicM.NumPartitions; i++ {
 					serr := sm.scheduleSubscription(ctx, sub, &nodeBindings)
@@ -319,8 +317,6 @@ func (sm *SchedulerTask) refreshNodeBindings(ctx context.Context) error {
 					}
 				}
 			}
-
-
 		}
 	}
 	return nil

--- a/internal/tasks/schedulertask.go
+++ b/internal/tasks/schedulertask.go
@@ -311,16 +311,18 @@ func (sm *SchedulerTask) refreshNodeBindings(ctx context.Context) error {
 					"subscription", sub.Name, "topic", sub.Topic, "subscription version", subVersion)
 				//return terr
 				continue
-			}
-
-			for i := 0; i < topicM.NumPartitions; i++ {
-				serr := sm.scheduleSubscription(ctx, sub, &nodeBindings)
-				if serr != nil {
-					logger.Ctx(ctx).Errorw("schedulertask: error in scheduling subscription", "err", serr, "subscription", sub.ExtractedSubscriptionName, "topic", sub.ExtractedTopicName, "partition", i)
-					//return serr
-					continue
+			} else {
+				for i := 0; i < topicM.NumPartitions; i++ {
+					serr := sm.scheduleSubscription(ctx, sub, &nodeBindings)
+					if serr != nil {
+						logger.Ctx(ctx).Errorw("schedulertask: error in scheduling subscription", "err", serr, "subscription", sub.ExtractedSubscriptionName, "topic", sub.ExtractedTopicName, "partition", i)
+						//return serr
+						continue
+					}
 				}
 			}
+
+
 		}
 	}
 	return nil

--- a/internal/tasks/schedulertask.go
+++ b/internal/tasks/schedulertask.go
@@ -316,8 +316,6 @@ func (sm *SchedulerTask) refreshNodeBindings(ctx context.Context) error {
 					serr := sm.scheduleSubscription(ctx, sub, &nodeBindings)
 					if serr != nil {
 						logger.Ctx(ctx).Errorw("schedulertask: error in scheduling subscription", "err", serr, "subscription", sub.ExtractedSubscriptionName, "topic", sub.ExtractedTopicName, "partition", i)
-						//return serr
-						continue
 					}
 				}
 			}


### PR DESCRIPTION
Currently, subscriptions exist without a corresponding topic (since topic deletion behavior is undefined). This has an effect on subscribers being set up without the actual topic to consume from.
This task ensures that such subscribers are not scheduled.