### PR TITLE
Added more metrics on subscription

### DIFF
--- a/internal/subscriber/metrics.go
+++ b/internal/subscriber/metrics.go
@@ -26,6 +26,8 @@ var (
 	subscriberTimeTakenToRemoveMsgFromMemory   *prometheus.HistogramVec
 	subscriberTimeTakenToIdentifyNextOffset    *prometheus.HistogramVec
 	subscriberTimeTakenToPushToRetry           *prometheus.HistogramVec
+	subscriberNumberOfReatinedAckedMessages    *prometheus.GaugeVec
+	subscriberReatinedAckedMessagesSize        *prometheus.GaugeVec
 )
 
 func init() {
@@ -118,4 +120,12 @@ func init() {
 		Help:    "Time taken to process retry message",
 		Buckets: prometheus.ExponentialBuckets(0.001, 1.1, 200),
 	}, []string{"env"})
+
+	subscriberNumberOfReatinedAckedMessages = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "metro_subscriber_retained_acked_messages",
+	}, []string{"env", "topic", "subscription"})
+
+	subscriberReatinedAckedMessagesSize = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "metro_subscriber_total_size_retained_acked_messages",
+	}, []string{"env", "topic", "subscription"})
 }

--- a/internal/subscriber/retry/delayconsumer.go
+++ b/internal/subscriber/retry/delayconsumer.go
@@ -126,6 +126,8 @@ func (dc *DelayConsumer) pushToDeadLetter(msg *messagebroker.ReceivedMessage) er
 		return err
 	}
 
+	subscriberTotalMessagesPushedToDLQ.WithLabelValues(env, msg.SourceTopic, msg.Subscription).Inc()
+
 	return nil
 }
 

--- a/internal/subscriber/retry/metrics.go
+++ b/internal/subscriber/retry/metrics.go
@@ -1,0 +1,21 @@
+package retry
+
+import (
+	"os"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	env                                string
+	subscriberTotalMessagesPushedToDLQ *prometheus.GaugeVec
+)
+
+func init() {
+	env = os.Getenv("APP_ENV")
+
+	subscriberTotalMessagesPushedToDLQ = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "metro_subscriber_messages_pushed_to_dlq",
+	}, []string{"env", "topic", "subscription"})
+}

--- a/internal/subscriber/subscriberimpl.go
+++ b/internal/subscriber/subscriberimpl.go
@@ -182,6 +182,8 @@ func (s *BasicImplementation) Acknowledge(ctx context.Context, req *AckMessage, 
 
 	subscriberMessagesAckd.WithLabelValues(env, s.topic, s.subscription.Name, s.subscriberID).Inc()
 	subscriberTimeTakenToAckMsg.WithLabelValues(env, s.topic, s.subscription.Name).Observe(time.Now().Sub(msg.PublishTime).Seconds())
+	subscriberNumberOfReatinedAckedMessages.WithLabelValues(env, s.topic, s.subscription.Name).Inc()
+	subscriberReatinedAckedMessagesSize.WithLabelValues(env, s.topic, s.subscription.Name).Add(float64(len(msg.Data)))
 }
 
 // ModAckDeadline modifies ack deadline


### PR DESCRIPTION
Following metrics are added

- Number of retained acked messages
- Total size in bytes of retained acked messages
- Number of messages pushed in dlq