### PR TITLE
Fix swagger path conflicts for OpenAPI spec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ proto-generate:
 	@buf generate --path ./metro-proto/metro/proto
 	# Substitute {param=...} path params into {param} to solve swagger substitution problem
 	# We add #header tags to work around OpenAPI limitations in detecting dunamic paths
-	@sed -E "s/\{([a-zA-Z0-9\.]+)=([a-zA-Z0-9]+)s([/])([\*])\/([a-zA-Z0-9]+)s([/])([\*])(.*)\}([:a-zA-Z0-9]*)/{\1}\9#\5/g" third_party/OpenAPI/proto/v1/spec.swagger.json > third_party/OpenAPI/proto/v1/spec.swagger.json.tmp
+	@sed -E "s/\{([a-zA-Z0-9\.]+)=([a-zA-Z0-9]+)([/])([\*])\/([a-zA-Z0-9]+)([/])([\*])(.*)\}([:a-zA-Z0-9]*)/{\1}\9#\5/g" third_party/OpenAPI/proto/v1/spec.swagger.json > third_party/OpenAPI/proto/v1/spec.swagger.json.tmp
 	@rm third_party/OpenAPI/proto/v1/spec.swagger.json
 	@mv third_party/OpenAPI/proto/v1/spec.swagger.json.tmp third_party/OpenAPI/proto/v1/spec.swagger.json
 	# Generate static assets for OpenAPI UI

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,8 @@ proto-generate:
 	@echo "\n + Generating pb language bindings\n"
 	@buf generate --path ./metro-proto/metro/proto
 	# Substitute {param=...} path params into {param} to solve swagger substitution problem
-	@sed -E "s/\{([a-zA-Z0-9\.]+)=[^\}]+\}/{\1}/g" third_party/OpenAPI/proto/v1/spec.swagger.json > third_party/OpenAPI/proto/v1/spec.swagger.json.tmp
+	# We add #header tags to work around OpenAPI limitations in detecting dunamic paths
+	@sed -E "s/\{([a-zA-Z0-9\.]+)=([a-zA-Z0-9]+)s([/])([\*])\/([a-zA-Z0-9]+)s([/])([\*])(.*)\}/{\1}#\5/g" third_party/OpenAPI/proto/v1/spec.swagger.json > third_party/OpenAPI/proto/v1/spec.swagger.json.tmp
 	@rm third_party/OpenAPI/proto/v1/spec.swagger.json
 	@mv third_party/OpenAPI/proto/v1/spec.swagger.json.tmp third_party/OpenAPI/proto/v1/spec.swagger.json
 	# Generate static assets for OpenAPI UI

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ proto-generate:
 	@buf generate --path ./metro-proto/metro/proto
 	# Substitute {param=...} path params into {param} to solve swagger substitution problem
 	# We add #header tags to work around OpenAPI limitations in detecting dunamic paths
-	@sed -E "s/\{([a-zA-Z0-9\.]+)=([a-zA-Z0-9]+)s([/])([\*])\/([a-zA-Z0-9]+)s([/])([\*])(.*)\}/{\1}#\5/g" third_party/OpenAPI/proto/v1/spec.swagger.json > third_party/OpenAPI/proto/v1/spec.swagger.json.tmp
+	@sed -E "s/\{([a-zA-Z0-9\.]+)=([a-zA-Z0-9]+)s([/])([\*])\/([a-zA-Z0-9]+)s([/])([\*])(.*)\}([:a-zA-Z0-9]*)/{\1}\9#\5/g" third_party/OpenAPI/proto/v1/spec.swagger.json > third_party/OpenAPI/proto/v1/spec.swagger.json.tmp
 	@rm third_party/OpenAPI/proto/v1/spec.swagger.json
 	@mv third_party/OpenAPI/proto/v1/spec.swagger.json.tmp third_party/OpenAPI/proto/v1/spec.swagger.json
 	# Generate static assets for OpenAPI UI


### PR DESCRIPTION
OpenAPI specification does not allow complex path substitutions such as `/v1/{name=projects/*/subscriptions/*}` in the URL.

This is resolved as `/v1/{name}` for brevity's sake which in turn results in equivalent URLs for multiple resources.
To solve this we add a `#anchor` tag of the resource name at the end of the URL to distinguish between both resources.

So `/v1/{name=projects/*/subscriptions/*}` translates to `/v1/{name}#subscriptions` in swagger spec.

Anchor tags are ignored by the downstream servers, hence this becomes a harmless addition.