### PR TITLE
Kafka producer client fine-tuning

### DIFF
--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -78,7 +78,7 @@ WORKDIR /app
 RUN apk add --update --no-cache dumb-init su-exec ca-certificates curl
 RUN mkdir -p /app/public
 
-EXPOSE 8081 8082 8083 8084 3000
+EXPOSE 8081 8082 8083 8084 3000 8080
 
 RUN chmod +x entrypoint.sh probe.sh
 ENTRYPOINT ["/app/entrypoint.sh", "metro"]

--- a/cmd/service/metro/metro.go
+++ b/cmd/service/metro/metro.go
@@ -14,6 +14,7 @@ import (
 	"github.com/razorpay/metro/pkg/logger"
 
 	"net/http"
+	// blank import added for testing.
 	_ "net/http/pprof"
 )
 

--- a/cmd/service/metro/metro.go
+++ b/cmd/service/metro/metro.go
@@ -14,6 +14,7 @@ import (
 	"github.com/razorpay/metro/pkg/logger"
 
 	"net/http"
+
 	// blank import added for testing.
 	_ "net/http/pprof"
 )
@@ -125,10 +126,9 @@ func Run(ctx context.Context) {
 func setPprofProfiles(ctx context.Context, componentName string) {
 	logger.Ctx(ctx).Infow("initialising pprof profiles")
 	go func() {
-		if componentName == Web {
-			http.ListenAndServe("metro-web-pprof.concierge.stage.razorpay.in:8080", nil)
-		} else if componentName == Worker {
-			http.ListenAndServe("metro-worker-pprof.concierge.stage.razorpay.in:8080", nil)
+		myMux := http.DefaultServeMux
+		if err := http.ListenAndServe("localhost:8080", myMux); err != nil {
+			logger.Ctx(ctx).Fatalw("Error when starting or running %v pprof http server: %v", componentName, err)
 		}
 	}()
 }

--- a/pkg/messagebroker/kafka.go
+++ b/pkg/messagebroker/kafka.go
@@ -109,21 +109,22 @@ func newKafkaProducerClient(ctx context.Context, bConfig *BrokerConfig, options 
 	logger.Ctx(ctx).Infow("kafka producer: initializing new", "options", options)
 
 	configMap := &kafkapkg.ConfigMap{
-		"bootstrap.servers":            strings.Join(bConfig.Brokers, ","),
-		"socket.keepalive.enable":      true,
-		"acks":                         1,
-		"retries":                      3,
-		"go.batch.producer":            false,
-		"linger.ms":                    0,
-		"request.timeout.ms":           3000,
-		"delivery.timeout.ms":          10000,
-		"connections.max.idle.ms":      180000,
-		"log.queue":                    false,
-		"queue.buffering.max.messages": 1000,
-		"go.logs.channel.enable":       false,
-		"go.events.channel.size":       100,
-		"go.produce.channel.size":      1000,
-		"go.delivery.reports":          false,
+		"bootstrap.servers":          strings.Join(bConfig.Brokers, ","),
+		"socket.keepalive.enable":    true,
+		"retries":                    3,
+		"linger.ms":                  0,
+		"request.timeout.ms":         3000,
+		"delivery.timeout.ms":        10000,
+		"connections.max.idle.ms":    180000,
+		"acks":                       1, // Num of In-Sync Broker Acks required.
+		"log.queue":                  false,
+		"queue.buffering.max.kbytes": 65536, // Total message size sum allocated in buffer. Shared across topics/partitions
+		"go.logs.channel.enable":     false, // Disable logs via channel
+		"go.events.channel.size":     1,     // Limit this to 1 to avoid outdated events
+		"go.produce.channel.size":    1000,  // Allocated buffer size for the produce channel.
+		"go.delivery.reports":        true,  // Returns delivery acks
+		"go.batch.producer":          false, // Disable batch producer since it clubs calls to librdkafka across topics. This causes memory bloat.
+		"debug":                      "broker",
 	}
 
 	if bConfig.EnableTLS {

--- a/pkg/messagebroker/kafka.go
+++ b/pkg/messagebroker/kafka.go
@@ -116,7 +116,7 @@ func newKafkaProducerClient(ctx context.Context, bConfig *BrokerConfig, options 
 		"request.timeout.ms":         3000,
 		"delivery.timeout.ms":        10000,
 		"connections.max.idle.ms":    180000,
-		"acks":                       1, // Num of In-Sync Broker Acks required.
+		"acks":                       1, // Number of In-Sync Broker Acks required.
 		"log.queue":                  false,
 		"queue.buffering.max.kbytes": 65536, // Total message size sum allocated in buffer. Shared across topics/partitions
 		"go.logs.channel.enable":     false, // Disable logs via channel

--- a/pkg/messagebroker/kafka.go
+++ b/pkg/messagebroker/kafka.go
@@ -113,6 +113,7 @@ func newKafkaProducerClient(ctx context.Context, bConfig *BrokerConfig, options 
 		"socket.keepalive.enable":      true,
 		"acks":                         1,
 		"retries":                      3,
+		"go.batch.producer":            true,
 		"linger.ms":                    0,
 		"request.timeout.ms":           3000,
 		"delivery.timeout.ms":          10000,

--- a/pkg/messagebroker/kafka.go
+++ b/pkg/messagebroker/kafka.go
@@ -124,7 +124,7 @@ func newKafkaProducerClient(ctx context.Context, bConfig *BrokerConfig, options 
 		"go.events.channel.size":       1,
 		"go.produce.channel.size":      1000,
 		"go.delivery.reports":          false,
-		"debug":                        "all",
+		"debug":                        "error",
 	}
 
 	if bConfig.EnableTLS {

--- a/pkg/messagebroker/kafka.go
+++ b/pkg/messagebroker/kafka.go
@@ -124,7 +124,6 @@ func newKafkaProducerClient(ctx context.Context, bConfig *BrokerConfig, options 
 		"go.events.channel.size":       1,
 		"go.produce.channel.size":      1000,
 		"go.delivery.reports":          false,
-		"go.batch.producer":            true,
 		"debug":                        "all",
 	}
 

--- a/pkg/messagebroker/kafka.go
+++ b/pkg/messagebroker/kafka.go
@@ -119,7 +119,9 @@ func newKafkaProducerClient(ctx context.Context, bConfig *BrokerConfig, options 
 		"connections.max.idle.ms":      180000,
 		"log.queue":                    false,
 		"queue.buffering.max.messages": 100,
-		"go.logs.channel.enable":       true,
+		"go.logs.channel.enable":       false,
+		"go.delivery.reports":          false,
+		"go.batch.producer":            true,
 		"debug":                        "all",
 	}
 

--- a/pkg/messagebroker/kafka.go
+++ b/pkg/messagebroker/kafka.go
@@ -113,7 +113,7 @@ func newKafkaProducerClient(ctx context.Context, bConfig *BrokerConfig, options 
 		"socket.keepalive.enable":      true,
 		"acks":                         1,
 		"retries":                      3,
-		"go.batch.producer":            true,
+		"go.batch.producer":            false,
 		"linger.ms":                    0,
 		"request.timeout.ms":           3000,
 		"delivery.timeout.ms":          10000,

--- a/pkg/messagebroker/kafka.go
+++ b/pkg/messagebroker/kafka.go
@@ -119,9 +119,9 @@ func newKafkaProducerClient(ctx context.Context, bConfig *BrokerConfig, options 
 		"delivery.timeout.ms":          10000,
 		"connections.max.idle.ms":      180000,
 		"log.queue":                    false,
-		"queue.buffering.max.messages": 100,
+		"queue.buffering.max.messages": 1000,
 		"go.logs.channel.enable":       false,
-		"go.events.channel.size":       1,
+		"go.events.channel.size":       100,
 		"go.produce.channel.size":      1000,
 		"go.delivery.reports":          false,
 	}

--- a/pkg/messagebroker/kafka.go
+++ b/pkg/messagebroker/kafka.go
@@ -109,15 +109,18 @@ func newKafkaProducerClient(ctx context.Context, bConfig *BrokerConfig, options 
 	logger.Ctx(ctx).Infow("kafka producer: initializing new", "options", options)
 
 	configMap := &kafkapkg.ConfigMap{
-		"bootstrap.servers":       strings.Join(bConfig.Brokers, ","),
-		"socket.keepalive.enable": true,
-		"retries":                 3,
-		"linger.ms":               0,
-		"request.timeout.ms":      3000,
-		"delivery.timeout.ms":     10000,
-		"connections.max.idle.ms": 180000,
-		"go.logs.channel.enable":  true,
-		"debug":                   "all",
+		"bootstrap.servers":            strings.Join(bConfig.Brokers, ","),
+		"socket.keepalive.enable":      true,
+		"acks":                         1,
+		"retries":                      3,
+		"linger.ms":                    0,
+		"request.timeout.ms":           3000,
+		"delivery.timeout.ms":          10000,
+		"connections.max.idle.ms":      180000,
+		"log.queue":                    false,
+		"queue.buffering.max.messages": 100,
+		"go.logs.channel.enable":       true,
+		"debug":                        "all",
 	}
 
 	if bConfig.EnableTLS {

--- a/pkg/messagebroker/kafka.go
+++ b/pkg/messagebroker/kafka.go
@@ -124,7 +124,6 @@ func newKafkaProducerClient(ctx context.Context, bConfig *BrokerConfig, options 
 		"go.events.channel.size":       1,
 		"go.produce.channel.size":      1000,
 		"go.delivery.reports":          false,
-		"debug":                        "error",
 	}
 
 	if bConfig.EnableTLS {


### PR DESCRIPTION
- Restricts buffer size 1M to 1k
- Eliminates batch producer mode
- Eliminates dedicated log channel.
- Restricts max queue buffer to 65Mb
- Expects only 1 ack from any of the ISBs
- Other minor improvements