### PR TITLE
Kafka producer tuning

### DIFF
--- a/config/prod.toml
+++ b/config/prod.toml
@@ -61,7 +61,7 @@
             caPem              = ""
 
 [cache]
-    driver                    = "consul"
+    driver                    = "redis"
     [cache.consulconfig]
         [cache.consulconfig.config]
             address            = "localhost:8500"

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/apache/pulsar-client-go v0.5.0
 	github.com/apache/pulsar-client-go/oauth2 v0.0.0-20210615012709-cb72395fb53f // indirect
 	github.com/armon/go-metrics v0.3.6 // indirect
-	github.com/confluentinc/confluent-kafka-go v1.7.0
+	github.com/confluentinc/confluent-kafka-go v1.8.2
 	github.com/danieljoos/wincred v1.1.0 // indirect
 	github.com/dvsekhvalnov/jose2go v0.0.0-20201001154944-b09cfaf05951 // indirect
 	github.com/fatih/color v1.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -122,6 +122,8 @@ github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWH
 github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0/go.mod h1:4Zcjuz89kmFXt9morQgcfYZAYZ5n8WHjt81YYWIwtTM=
 github.com/confluentinc/confluent-kafka-go v1.7.0 h1:tXh3LWb2Ne0WiU3ng4h5qiGA9XV61rz46w60O+cq8bM=
 github.com/confluentinc/confluent-kafka-go v1.7.0/go.mod h1:u2zNLny2xq+5rWeTQjFHbDzzNuba4P1vo31r9r4uAdg=
+github.com/confluentinc/confluent-kafka-go v1.8.2 h1:PBdbvYpyOdFLehj8j+9ba7FL4c4Moxn79gy9cYKxG5E=
+github.com/confluentinc/confluent-kafka-go v1.8.2/go.mod h1:u2zNLny2xq+5rWeTQjFHbDzzNuba4P1vo31r9r4uAdg=
 github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/pkg/messagebroker/kafka.go
+++ b/pkg/messagebroker/kafka.go
@@ -118,7 +118,7 @@ func newKafkaProducerClient(ctx context.Context, bConfig *BrokerConfig, options 
 		"connections.max.idle.ms":    180000,
 		"log.queue":                  true,
 		"queue.buffering.max.kbytes": 65536, // Total message size sum allocated in buffer. Shared across topics/partitions
-		"go.logs.channel.enable":     true,  // Disable logs via channel
+		"go.logs.channel.enable":     false, // Disable logs via channel
 		"go.events.channel.size":     10,    // Limit this to 1 to avoid outdated events
 		"go.produce.channel.size":    1000,  // Allocated buffer size for the produce channel.
 		"go.delivery.reports":        true,  // Returns delivery acks

--- a/pkg/messagebroker/kafka.go
+++ b/pkg/messagebroker/kafka.go
@@ -114,14 +114,14 @@ func newKafkaProducerClient(ctx context.Context, bConfig *BrokerConfig, options 
 		"retries":                    3,
 		"linger.ms":                  0,
 		"request.timeout.ms":         3000,
-		"delivery.timeout.ms":        10000,
+		"delivery.timeout.ms":        2000,
 		"connections.max.idle.ms":    180000,
 		"log.queue":                  true,
 		"queue.buffering.max.kbytes": 65536, // Total message size sum allocated in buffer. Shared across topics/partitions
 		"go.logs.channel.enable":     true,  // Disable logs via channel
 		"go.events.channel.size":     10,    // Limit this to 1 to avoid outdated events
 		"go.produce.channel.size":    1000,  // Allocated buffer size for the produce channel.
-		"go.delivery.reports":        false, // Returns delivery acks
+		"go.delivery.reports":        true,  // Returns delivery acks
 		"go.batch.producer":          false, // Disable batch producer since it clubs calls to librdkafka across topics. This causes memory bloat.
 		"debug":                      "broker",
 	}

--- a/pkg/messagebroker/kafka.go
+++ b/pkg/messagebroker/kafka.go
@@ -404,13 +404,13 @@ func (k *KafkaBroker) SendMessage(ctx context.Context, request SendMessageToTopi
 		messageBrokerOperationError.WithLabelValues(env, Kafka, "SendMessage", err.Error()).Inc()
 		return nil, err
 	}
-
+	logger.Ctx(ctx).Infow("successfully sent messsage and waiting for ack callback", "msgId", request.MessageID)
 	var m *kafkapkg.Message
 	select {
 	case event := <-deliveryChan:
 		m = event.(*kafkapkg.Message)
 	}
-
+	logger.Ctx(ctx).Infow("successfully received callback", "msgId", request.MessageID)
 	if m != nil && m.TopicPartition.Error != nil {
 		logger.Ctx(ctx).Errorw("kafka: error in publishing messages", "error", m.TopicPartition.Error.Error())
 		messageBrokerOperationError.WithLabelValues(env, Kafka, "SendMessage", m.TopicPartition.Error.Error()).Inc()

--- a/pkg/messagebroker/kafka.go
+++ b/pkg/messagebroker/kafka.go
@@ -116,13 +116,12 @@ func newKafkaProducerClient(ctx context.Context, bConfig *BrokerConfig, options 
 		"request.timeout.ms":         3000,
 		"delivery.timeout.ms":        10000,
 		"connections.max.idle.ms":    180000,
-		"acks":                       1, // Number of In-Sync Broker Acks required.
 		"log.queue":                  false,
 		"queue.buffering.max.kbytes": 65536, // Total message size sum allocated in buffer. Shared across topics/partitions
 		"go.logs.channel.enable":     false, // Disable logs via channel
 		"go.events.channel.size":     1,     // Limit this to 1 to avoid outdated events
 		"go.produce.channel.size":    1000,  // Allocated buffer size for the produce channel.
-		"go.delivery.reports":        true,  // Returns delivery acks
+		"go.delivery.reports":        false, // Returns delivery acks
 		"go.batch.producer":          false, // Disable batch producer since it clubs calls to librdkafka across topics. This causes memory bloat.
 		"debug":                      "broker",
 	}

--- a/pkg/messagebroker/kafka.go
+++ b/pkg/messagebroker/kafka.go
@@ -109,21 +109,21 @@ func newKafkaProducerClient(ctx context.Context, bConfig *BrokerConfig, options 
 	logger.Ctx(ctx).Infow("kafka producer: initializing new", "options", options)
 
 	configMap := &kafkapkg.ConfigMap{
-		"bootstrap.servers":          strings.Join(bConfig.Brokers, ","),
-		"socket.keepalive.enable":    true,
-		"retries":                    3,
-		"linger.ms":                  0,
-		"request.timeout.ms":         3000,
-		"delivery.timeout.ms":        2000,
-		"connections.max.idle.ms":    180000,
-		"log.queue":                  true,
-		"queue.buffering.max.kbytes": 65536, // Total message size sum allocated in buffer. Shared across topics/partitions
-		"go.logs.channel.enable":     false, // Disable logs via channel
-		"go.events.channel.size":     10,    // Limit this to 1 to avoid outdated events
-		"go.produce.channel.size":    1000,  // Allocated buffer size for the produce channel.
-		"go.delivery.reports":        true,  // Returns delivery acks
-		"go.batch.producer":          false, // Disable batch producer since it clubs calls to librdkafka across topics. This causes memory bloat.
-		"debug":                      "broker",
+		"bootstrap.servers":       strings.Join(bConfig.Brokers, ","),
+		"socket.keepalive.enable": true,
+		"retries":                 3,
+		"linger.ms":               0,
+		"request.timeout.ms":      3000,
+		"delivery.timeout.ms":     2000,
+		"connections.max.idle.ms": 180000,
+		// "log.queue":                  true,
+		// "queue.buffering.max.kbytes": 65536, // Total message size sum allocated in buffer. Shared across topics/partitions
+		// "go.logs.channel.enable":     false, // Disable logs via channel
+		// "go.events.channel.size":     10,    // Limit this to 1 to avoid outdated events
+		// "go.produce.channel.size":    1000,  // Allocated buffer size for the produce channel.
+		// "go.delivery.reports":        true,  // Returns delivery acks
+		// "go.batch.producer":          false, // Disable batch producer since it clubs calls to librdkafka across topics. This causes memory bloat.
+		"debug": "broker",
 	}
 
 	if bConfig.EnableTLS {

--- a/pkg/messagebroker/kafka.go
+++ b/pkg/messagebroker/kafka.go
@@ -116,10 +116,10 @@ func newKafkaProducerClient(ctx context.Context, bConfig *BrokerConfig, options 
 		"request.timeout.ms":         3000,
 		"delivery.timeout.ms":        10000,
 		"connections.max.idle.ms":    180000,
-		"log.queue":                  false,
+		"log.queue":                  true,
 		"queue.buffering.max.kbytes": 65536, // Total message size sum allocated in buffer. Shared across topics/partitions
-		"go.logs.channel.enable":     false, // Disable logs via channel
-		"go.events.channel.size":     1,     // Limit this to 1 to avoid outdated events
+		"go.logs.channel.enable":     true,  // Disable logs via channel
+		"go.events.channel.size":     10,    // Limit this to 1 to avoid outdated events
 		"go.produce.channel.size":    1000,  // Allocated buffer size for the produce channel.
 		"go.delivery.reports":        false, // Returns delivery acks
 		"go.batch.producer":          false, // Disable batch producer since it clubs calls to librdkafka across topics. This causes memory bloat.

--- a/pkg/messagebroker/kafka.go
+++ b/pkg/messagebroker/kafka.go
@@ -116,6 +116,7 @@ func newKafkaProducerClient(ctx context.Context, bConfig *BrokerConfig, options 
 		"request.timeout.ms":      3000,
 		"delivery.timeout.ms":     2000,
 		"connections.max.idle.ms": 180000,
+		"go.log.channel.enable":   true,
 		// "log.queue":                  true,
 		// "queue.buffering.max.kbytes": 65536, // Total message size sum allocated in buffer. Shared across topics/partitions
 		// "go.logs.channel.enable":     false, // Disable logs via channel

--- a/pkg/messagebroker/kafka.go
+++ b/pkg/messagebroker/kafka.go
@@ -148,6 +148,12 @@ func newKafkaProducerClient(ctx context.Context, bConfig *BrokerConfig, options 
 		select {
 		case <-ctx.Done():
 			return
+		case events := <-p.Events():
+			logger.Ctx(ctx).Infow("Receieved event from producer", "producer", p.String(), "event", events.String())
+			ferr := p.GetFatalError()
+			if ferr != nil {
+				logger.Ctx(ctx).Errorw("Fatar error encountered for producer", "producer", p.String(), "error", ferr.Error())
+			}
 		case log := <-p.Logs():
 			logger.Ctx(ctx).Infow("kafka producer logs", "topic", options.Topic, "log", log.String())
 		}

--- a/pkg/messagebroker/kafka.go
+++ b/pkg/messagebroker/kafka.go
@@ -109,15 +109,22 @@ func newKafkaProducerClient(ctx context.Context, bConfig *BrokerConfig, options 
 	logger.Ctx(ctx).Infow("kafka producer: initializing new", "options", options)
 
 	configMap := &kafkapkg.ConfigMap{
-		"bootstrap.servers":       strings.Join(bConfig.Brokers, ","),
-		"socket.keepalive.enable": true,
-		"retries":                 3,
-		"linger.ms":               0,
-		"request.timeout.ms":      3000,
-		"delivery.timeout.ms":     10000,
-		"connections.max.idle.ms": 180000,
-		"go.logs.channel.enable":  true,
-		"debug":                   "all",
+		"bootstrap.servers":          strings.Join(bConfig.Brokers, ","),
+		"socket.keepalive.enable":    true,
+		"retries":                    3,
+		"linger.ms":                  0,
+		"request.timeout.ms":         3000,
+		"delivery.timeout.ms":        10000,
+		"connections.max.idle.ms":    180000,
+		"acks":                       1, // Number of In-Sync Broker Acks required.
+		"log.queue":                  false,
+		"queue.buffering.max.kbytes": 65536, // Total message size sum allocated in buffer. Shared across topics/partitions
+		"go.logs.channel.enable":     false, // Disable logs via channel
+		"go.events.channel.size":     1,     // Limit this to 1 to avoid outdated events
+		"go.produce.channel.size":    1000,  // Allocated buffer size for the produce channel.
+		"go.delivery.reports":        true,  // Returns delivery acks
+		"go.batch.producer":          false, // Disable batch producer since it clubs calls to librdkafka across topics. This causes memory bloat.
+		"debug":                      "broker",
 	}
 
 	if bConfig.EnableTLS {


### PR DESCRIPTION
Delivery report delays cause requests to timeout.Disabling reports and Acks to facilitate async message producers