### PR TITLE
Revert "Kafka producer tuning (#327)"

### DIFF
--- a/.github/.golangci.yml
+++ b/.github/.golangci.yml
@@ -88,7 +88,7 @@ linters:
 run:
   timeout: 5m
   skip-files:
-    - ".*\\.kafka\\.go$"
+    - ".*confluentinc.*$"
   skip-dirs:
     - vendor
     - third_party

--- a/.github/.golangci.yml
+++ b/.github/.golangci.yml
@@ -45,6 +45,9 @@ linters-settings:
     require-explanation: false # don't require an explanation for nolint directives
     require-specific: false # don't require nolint directives to be specific about which linter is being skipped
 
+severity:
+ default-severity: error
+
 linters:
   disable-all: true
   enable:

--- a/.github/.golangci.yml
+++ b/.github/.golangci.yml
@@ -87,6 +87,8 @@ linters:
 
 run:
   timeout: 5m
+  skip-files:
+    - ".*\\.kafka\\.go$"
   skip-dirs:
     - vendor
     - third_party

--- a/.github/.golangci.yml
+++ b/.github/.golangci.yml
@@ -97,3 +97,4 @@ run:
     - third_party
     - statik
     - tests
+  go: '1.16'

--- a/.github/workflows/review_ci.yml
+++ b/.github/workflows/review_ci.yml
@@ -19,7 +19,7 @@ jobs:
           submodules: true
       - name: install prerequisites
         run: |
-          apk add --update --no-cache --repository https://dl-4.alpinelinux.org/alpine/latest-stable/community/ build-base gcc make git librdkafka-dev pkgconf curl bash
+          apk add --update --no-cache --repository https://dl-4.alpinelinux.org/alpine/latest-stable/community/ build-base gcc make git librdkafka-dev pkgconf curl bash sudo
       - name: setup
         run: |
           make deps proto-generate mock-gen

--- a/.github/workflows/review_ci.yml
+++ b/.github/workflows/review_ci.yml
@@ -24,6 +24,7 @@ jobs:
         run: |
           make deps proto-generate mock-gen
           go mod vendor
+          go mod tidy
       - name: golangci-lint
         uses: reviewdog/action-golangci-lint@v1
         with:

--- a/.github/workflows/review_ci.yml
+++ b/.github/workflows/review_ci.yml
@@ -24,7 +24,9 @@ jobs:
         run: |
           make deps proto-generate mock-gen
           go mod vendor
-          go mod tidy
+      - name: Target repo permission update # Workaround for CVE-2022-24765  
+        run: |
+          sudo chown -R root:root $GITHUB_WORKSPACE
       - name: golangci-lint
         uses: reviewdog/action-golangci-lint@v1
         with:

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/apache/pulsar-client-go v0.5.0
 	github.com/apache/pulsar-client-go/oauth2 v0.0.0-20210615012709-cb72395fb53f // indirect
 	github.com/armon/go-metrics v0.3.6 // indirect
-	github.com/confluentinc/confluent-kafka-go v1.8.2
+	github.com/confluentinc/confluent-kafka-go v1.7.0
 	github.com/danieljoos/wincred v1.1.0 // indirect
 	github.com/dvsekhvalnov/jose2go v0.0.0-20201001154944-b09cfaf05951 // indirect
 	github.com/fatih/color v1.10.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/dvsekhvalnov/jose2go v0.0.0-20201001154944-b09cfaf05951 // indirect
 	github.com/fatih/color v1.10.0 // indirect
 	github.com/getsentry/sentry-go v0.11.0
-	github.com/go-redis/redis v6.15.9+incompatible // indirect
+	github.com/go-redis/redis v6.15.9+incompatible
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/mock v1.6.0
 	github.com/golang/protobuf v1.5.2

--- a/go.sum
+++ b/go.sum
@@ -122,8 +122,6 @@ github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWH
 github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0/go.mod h1:4Zcjuz89kmFXt9morQgcfYZAYZ5n8WHjt81YYWIwtTM=
 github.com/confluentinc/confluent-kafka-go v1.7.0 h1:tXh3LWb2Ne0WiU3ng4h5qiGA9XV61rz46w60O+cq8bM=
 github.com/confluentinc/confluent-kafka-go v1.7.0/go.mod h1:u2zNLny2xq+5rWeTQjFHbDzzNuba4P1vo31r9r4uAdg=
-github.com/confluentinc/confluent-kafka-go v1.8.2 h1:PBdbvYpyOdFLehj8j+9ba7FL4c4Moxn79gy9cYKxG5E=
-github.com/confluentinc/confluent-kafka-go v1.8.2/go.mod h1:u2zNLny2xq+5rWeTQjFHbDzzNuba4P1vo31r9r4uAdg=
 github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=


### PR DESCRIPTION
This reverts commit 4f8c13d8aeb90a9c65e41ae95e4f6e1cf13906c5.
Also fixes issue with git CVE-2022-24765 vulnerability causing reviewdog to return an error