### PR TITLE
subscriber level healthchecks

### DIFF
--- a/internal/stream/metrics.go
+++ b/internal/stream/metrics.go
@@ -15,7 +15,7 @@ var (
 	workerPushEndpointTimeTaken      *prometheus.HistogramVec
 	workerSubscriberErrors           *prometheus.CounterVec
 	workerPushEndpointCallsCount     *prometheus.CounterVec
-	workerEntityRestartCount         *prometheus.CounterVec
+	workerComponentRestartCount      *prometheus.CounterVec
 )
 
 func init() {
@@ -47,7 +47,7 @@ func init() {
 		Name: "metro_worker_push_endpoint_http_calls",
 	}, []string{"env", "topic", "subscription", "endpoint", "subscriberId"})
 
-	workerEntityRestartCount = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name: "metro_worker_subscriber_restart_count",
-	}, []string{"env", "entity", "topic", "subscription"})
+	workerComponentRestartCount = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "metro_worker_component_restart_count",
+	}, []string{"env", "component", "topic", "subscription"})
 }

--- a/internal/stream/metrics.go
+++ b/internal/stream/metrics.go
@@ -15,6 +15,7 @@ var (
 	workerPushEndpointTimeTaken      *prometheus.HistogramVec
 	workerSubscriberErrors           *prometheus.CounterVec
 	workerPushEndpointCallsCount     *prometheus.CounterVec
+	workerEntityRestartCount         *prometheus.CounterVec
 )
 
 func init() {
@@ -45,4 +46,8 @@ func init() {
 	workerPushEndpointCallsCount = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "metro_worker_push_endpoint_http_calls",
 	}, []string{"env", "topic", "subscription", "endpoint", "subscriberId"})
+
+	workerEntityRestartCount = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "metro_worker_subscriber_restart_count",
+	}, []string{"env", "entity", "topic", "subscription"})
 }

--- a/internal/stream/stream.go
+++ b/internal/stream/stream.go
@@ -164,13 +164,23 @@ func (ps *PushStream) Stop() error {
 // Restart is used to restart the push subscription processing
 func (ps *PushStream) Restart(ctx context.Context) {
 	logger.Ctx(ps.ctx).Infow("worker: push stream restart invoked", "subscription", ps.subscription.Name)
-	ps.Stop()
+	err := ps.Stop()
+	if err != nil {
+		logger.Ctx(ctx).Errorw(
+			"worker: push stream stop error",
+			"subscription", ps.subscription.Name,
+			"error", err,
+		)
+		return
+	}
 	go func(ctx context.Context) {
 		err := ps.Start()
 		if err != nil {
-			logger.Ctx(ctx).Errorw("[worker]: push stream restart error",
+			logger.Ctx(ctx).Errorw(
+				"worker: push stream restart error",
 				"subscription", ps.subscription.Name,
-				"error", err.Error())
+				"error", err.Error(),
+			)
 		}
 	}(ctx)
 	workerEntityRestartCount.WithLabelValues(env, "stream", ps.subscription.Topic, ps.subscription.Name).Inc()

--- a/internal/stream/stream.go
+++ b/internal/stream/stream.go
@@ -160,6 +160,7 @@ func (ps *PushStream) Stop() error {
 	return nil
 }
 
+// Restart is used to restart the push subscription processing
 func (ps *PushStream) Restart(ctx context.Context) {
 	logger.Ctx(ps.ctx).Infow("worker: push stream restart invoked", "subscription", ps.subscription.Name)
 	ps.Stop()

--- a/internal/stream/stream.go
+++ b/internal/stream/stream.go
@@ -40,6 +40,7 @@ const (
 	defaultMaxOuttandingBytes int64 = 0
 )
 
+// GetRestartChannel returns the chan where restart request is received
 func (ps *PushStream) GetRestartChannel() chan bool {
 	return ps.restartChan
 }

--- a/internal/subscriber/core.go
+++ b/internal/subscriber/core.go
@@ -28,6 +28,9 @@ type Core struct {
 	ch               cache.ICache
 }
 
+// DefaultLimitForErrChannel ...
+var DefaultLimitForErrChannel int32 = 1000
+
 // NewCore returns a new subscriber core
 func NewCore(bs brokerstore.IBrokerStore, subscriptionCore subscription.ICore, offsetCore offset.ICore, ch cache.ICache) ICore {
 	return &Core{bs: bs, subscriptionCore: subscriptionCore, offsetCore: offsetCore, ch: ch}
@@ -51,7 +54,7 @@ func (c *Core) NewSubscriber(ctx context.Context,
 	}
 
 	subsCtx, cancelFunc := context.WithCancel(ctx)
-	errChan := make(chan error, 1000)
+	errChan := make(chan error, DefaultLimitForErrChannel)
 
 	// using the subscriber ctx for retrier as well. This way when the ctx() for subscribers is done,
 	// all the delay-consumers spawned within retrier would also get marked as done.

--- a/internal/subscriber/core.go
+++ b/internal/subscriber/core.go
@@ -28,9 +28,6 @@ type Core struct {
 	ch               cache.ICache
 }
 
-// DefaultLimitForErrChannel ...
-var DefaultLimitForErrChannel int32 = 1000
-
 // NewCore returns a new subscriber core
 func NewCore(bs brokerstore.IBrokerStore, subscriptionCore subscription.ICore, offsetCore offset.ICore, ch cache.ICache) ICore {
 	return &Core{bs: bs, subscriptionCore: subscriptionCore, offsetCore: offsetCore, ch: ch}
@@ -54,7 +51,7 @@ func (c *Core) NewSubscriber(ctx context.Context,
 	}
 
 	subsCtx, cancelFunc := context.WithCancel(ctx)
-	errChan := make(chan error, DefaultLimitForErrChannel)
+	errChan := make(chan error)
 
 	// using the subscriber ctx for retrier as well. This way when the ctx() for subscribers is done,
 	// all the delay-consumers spawned within retrier would also get marked as done.

--- a/internal/subscriber/core.go
+++ b/internal/subscriber/core.go
@@ -51,6 +51,8 @@ func (c *Core) NewSubscriber(ctx context.Context,
 	}
 
 	subsCtx, cancelFunc := context.WithCancel(ctx)
+	errChan := make(chan error, 1000)
+
 	// using the subscriber ctx for retrier as well. This way when the ctx() for subscribers is done,
 	// all the delay-consumers spawned within retrier would also get marked as done.
 	var retrier retry.IRetrier
@@ -64,6 +66,7 @@ func (c *Core) NewSubscriber(ctx context.Context,
 			WithIntervalFinder(retry.NewClosestIntervalWithCeil()).
 			WithMessageHandler(retry.NewPushToPrimaryRetryTopicHandler(c.bs)).
 			WithSubscriberID(subscriberID).
+			WithErrChan(errChan).
 			Build()
 
 		err = retrier.Start(subsCtx)
@@ -111,7 +114,7 @@ func (c *Core) NewSubscriber(ctx context.Context,
 		subscriberID:   subscriberID,
 		requestChan:    requestCh,
 		responseChan:   make(chan *metrov1.PullResponse),
-		errChan:        make(chan error, 1000),
+		errChan:        errChan,
 		closeChan:      make(chan struct{}),
 		ackChan:        ackCh,
 		modAckChan:     modAckCh,

--- a/internal/subscriber/retry/builder.go
+++ b/internal/subscriber/retry/builder.go
@@ -17,6 +17,7 @@ type Builder interface {
 	WithSubscription(subs *subscription.Model) Builder
 	WithMessageHandler(handler MessageHandler) Builder
 	WithSubscriberID(subscriberID string) Builder
+	WithErrChan(chan error) Builder
 	Build() IRetrier
 }
 
@@ -69,5 +70,11 @@ func (retrier *Retrier) WithMessageHandler(handler MessageHandler) Builder {
 // WithSubscriberID ...
 func (retrier *Retrier) WithSubscriberID(subscriberID string) Builder {
 	retrier.subscriberID = subscriberID
+	return retrier
+}
+
+// WithErrChan ...
+func (retrier *Retrier) WithErrChan(errChan chan error) Builder {
+	retrier.errChan = errChan
 	return retrier
 }

--- a/internal/subscriber/retry/delayconsumer.go
+++ b/internal/subscriber/retry/delayconsumer.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/razorpay/metro/internal/brokerstore"
 	"github.com/razorpay/metro/internal/subscription"
-	"github.com/razorpay/metro/internal/topic"
+	topicName "github.com/razorpay/metro/internal/topic"
 	"github.com/razorpay/metro/pkg/cache"
 	"github.com/razorpay/metro/pkg/logger"
 	"github.com/razorpay/metro/pkg/messagebroker"
@@ -151,7 +151,7 @@ func (dc *DelayConsumer) processMsgs() {
 		if msg.CanProcessMessage() {
 			if dc.retryExhausted(msg) || (msg.CurrentRetryCount > msg.MaxRetryCount) {
 				// if the source topic is dlq-topic, message will be lost after exhausting max retries.
-				if !topic.IsDLQTopic(dc.subs.GetTopic()) {
+				if !topicName.IsDLQTopic(dc.subs.GetTopic()) {
 					// push to dead-letter topic directly in such cases
 					logger.Ctx(dc.ctx).Infow("delay-consumer: publishing to DLQ topic", dc.LogFields("messageID", msg.MessageID)...)
 					err := dc.pushToDeadLetter(&msg)

--- a/internal/subscriber/retry/delayconsumer_test.go
+++ b/internal/subscriber/retry/delayconsumer_test.go
@@ -58,7 +58,7 @@ func TestDelayConsumer_Run(t *testing.T) {
 	mockConsumer.EXPECT().Resume(gomock.AssignableToTypeOf(ctx), gomock.Any()).Return(nil).AnyTimes()
 
 	// initialize delay consumer
-	dc, err := NewDelayConsumer(ctx, subscriberID, "t1", subs, mockBrokerStore, mockHandler, cache)
+	dc, err := NewDelayConsumer(ctx, subscriberID, "t1", subs, mockBrokerStore, mockHandler, cache, make(chan error))
 	assert.NotNil(t, dc)
 	assert.Nil(t, err)
 	assert.NotNil(t, dc.LogFields())

--- a/internal/subscriber/retry/retrier.go
+++ b/internal/subscriber/retry/retrier.go
@@ -34,6 +34,7 @@ type Retrier struct {
 	finder         IntervalFinder
 	handler        MessageHandler
 	delayConsumers sync.Map
+	errChan        chan error
 }
 
 // Start starts a new retrier which internally takes care of spawning the needed delay-consumers.
@@ -56,7 +57,7 @@ func (r *Retrier) Start(ctx context.Context) error {
 	})
 	for interval, topic := range r.subs.GetDelayTopicsMap() {
 		if uint(interval) <= uint(predefinedInterval) {
-			dc, err := NewDelayConsumer(ctx, r.subscriberID, topic, r.subs, r.bs, r.handler, r.ch)
+			dc, err := NewDelayConsumer(ctx, r.subscriberID, topic, r.subs, r.bs, r.handler, r.ch, r.errChan)
 			if err != nil {
 				return err
 			}

--- a/internal/subscriber/subscriber.go
+++ b/internal/subscriber/subscriber.go
@@ -133,13 +133,6 @@ func (s *Subscriber) Run(ctx context.Context) {
 			}
 			s.subscriberImpl.EvictUnackedMessagesPastDeadline(ctx, s.GetErrorChannel())
 			subscriberTimeTakenInDeadlineChannelCase.WithLabelValues(env, s.topic, s.subscription.Name).Observe(time.Now().Sub(caseStartTime).Seconds())
-		case err := <-s.errChan:
-			if ctx.Err() != nil {
-				continue
-			}
-			if err != nil {
-				logger.Ctx(ctx).Errorw("subscriber: got error on errCh channel", "logFields", s.getLogFields(), "error", err.Error())
-			}
 		case <-ctx.Done():
 			logger.Ctx(ctx).Infow("subscriber: <-ctx.Done() called", "logFields", s.getLogFields())
 

--- a/internal/tasks/subscriptiontask.go
+++ b/internal/tasks/subscriptiontask.go
@@ -193,10 +193,8 @@ func (sm *SubscriptionTask) handleNodeBindingUpdates(ctx context.Context, newBin
 			logger.Ctx(ctx).Infow("binding removed", "key", oldKey)
 			if handler, ok := sm.pushHandlers.Load(oldKey); ok && handler != nil {
 				logger.Ctx(ctx).Infow("handler found, calling stop", "key", oldKey)
-				go func(ctx context.Context) {
-					handler.(*stream.PushStream).GetStopChannel() <- true
-					logger.Ctx(ctx).Infow("handler stopped", "key", oldKey)
-				}(ctx)
+				handler.(*stream.PushStream).GetStopChannel() <- true
+				logger.Ctx(ctx).Infow("handler stopped", "key", oldKey)
 				sm.pushHandlers.Delete(oldKey)
 			}
 		}

--- a/internal/tasks/subscriptiontask.go
+++ b/internal/tasks/subscriptiontask.go
@@ -255,7 +255,11 @@ func (sm *SubscriptionTask) stopPushHandlers(ctx context.Context) {
 		go func(ps *stream.PushStream, wg *sync.WaitGroup) {
 			defer wg.Done()
 
-			ps.GetStopChannel() <- true
+			err := ps.Stop()
+			if err != nil {
+				logger.Ctx(ctx).Errorw("error stopping stream handler", "error", err)
+				return
+			}
 			logger.Ctx(ctx).Infow("successfully stopped stream handler")
 		}(ps, &wg)
 		return true

--- a/internal/tasks/subscriptiontask.go
+++ b/internal/tasks/subscriptiontask.go
@@ -232,11 +232,9 @@ func (sm *SubscriptionTask) handleNodeBindingUpdates(ctx context.Context, newBin
 			go func(ctx context.Context) {
 				err := handler.Start()
 				if err != nil {
-					logger.Ctx(ctx).Errorw(
-						"[worker]: push stream handler exited",
+					logger.Ctx(ctx).Errorw("[worker]: push stream handler exited",
 						"subscription", newBinding.SubscriptionID,
-						"error", err.Error(),
-					)
+						"error", err.Error())
 				}
 
 				for {

--- a/internal/tasks/subscriptiontask_test.go
+++ b/internal/tasks/subscriptiontask_test.go
@@ -246,4 +246,5 @@ func TestSubscriptionTask_handleNodeBindingUpdates(t *testing.T) {
 	close(task.(*SubscriptionTask).watchCh)
 	cancel()
 	<-doneCh
+	assert.Fail(t, "test")
 }

--- a/internal/tasks/subscriptiontask_test.go
+++ b/internal/tasks/subscriptiontask_test.go
@@ -246,5 +246,4 @@ func TestSubscriptionTask_handleNodeBindingUpdates(t *testing.T) {
 	close(task.(*SubscriptionTask).watchCh)
 	cancel()
 	<-doneCh
-	assert.Fail(t, "test")
 }

--- a/internal/tasks/subscriptiontask_test.go
+++ b/internal/tasks/subscriptiontask_test.go
@@ -1,3 +1,4 @@
+//go:build unit
 // +build unit
 
 package tasks
@@ -191,7 +192,7 @@ func TestSubscriptionTask_handleNodeBindingUpdates(t *testing.T) {
 		gomock.Any(),
 		gomock.Any(),
 		gomock.Any(),
-		gomock.Any()).Return(subscriberMock, nil)
+		gomock.Any()).Return(subscriberMock, nil).AnyTimes()
 
 	// mock subscriber
 	reqCh := make(chan *subscriber.PullRequest)
@@ -202,7 +203,7 @@ func TestSubscriptionTask_handleNodeBindingUpdates(t *testing.T) {
 	subscriberMock.EXPECT().GetResponseChannel().Return(resCh).AnyTimes()
 	subscriberMock.EXPECT().Stop().Do(func() {
 		close(resCh)
-	})
+	}).AnyTimes()
 
 	doneCh := make(chan struct{})
 


### PR DESCRIPTION
1. Adding delay consumer errors to subscriber err channel
2. Restart subscriber for any error on its err channel
3. Restart stream for any error while running stream 