### PR TITLE
Filtering update fix

### DIFF
--- a/internal/subscription/proto.go
+++ b/internal/subscription/proto.go
@@ -44,5 +44,9 @@ func ModelToSubscriptionProtoV1(m *Model) *metrov1.Subscription {
 		}
 	}
 
+	if m.FilterExpression != "" {
+		proto.Filter = m.FilterExpression
+	}
+
 	return proto
 }

--- a/internal/subscription/validation.go
+++ b/internal/subscription/validation.go
@@ -29,6 +29,7 @@ const (
 	ackDeadlineSecPath   = "ack_deadline_seconds"
 	retryConfigPath      = "retry_policy"
 	deadLetterConfigPath = "dead_letter_policy"
+	filterPath           = "filter"
 )
 
 // Config validations related values
@@ -169,7 +170,7 @@ func ValidateUpdateSubscriptionRequest(_ context.Context, req *metrov1.UpdateSub
 	for _, path := range req.UpdateMask.Paths {
 		switch path {
 		// valid paths
-		case pushConfigPath, ackDeadlineSecPath, retryConfigPath, deadLetterConfigPath:
+		case pushConfigPath, ackDeadlineSecPath, retryConfigPath, deadLetterConfigPath, filterPath:
 			continue
 		default:
 			return merror.Newf(merror.InvalidArgument, "invalid update_mask provided. '%s' is not a known update_mask", path)


### PR DESCRIPTION
- While updating a subscription the response contains the updated subscription model, but does not contain the filter criteria in it. This is misleading and the PR aims to fix the same.