### PR TITLE
Metro 71 fix zombie subscribers to avoid refreshing bindings

### DIFF
--- a/internal/subscriber/metrics.go
+++ b/internal/subscriber/metrics.go
@@ -30,7 +30,6 @@ var (
 	subscriberRetainedAckedMessagesSize        *prometheus.GaugeVec
 	subscriberLastMsgProcessingTime            *prometheus.GaugeVec
 	subscriberPartitionConsumerLag             *prometheus.GaugeVec
-	subscriberConsumerLag                      *prometheus.GaugeVec
 )
 
 func init() {
@@ -139,8 +138,4 @@ func init() {
 	subscriberPartitionConsumerLag = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "metro_subscriber_calculated_partition_consumer_lag",
 	}, []string{"env", "topic", "subscription", "partition"})
-
-	subscriberConsumerLag = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "metro_subscriber_calculated_consumer_lag",
-	}, []string{"env", "topic", "subscription"})
 }

--- a/internal/subscriber/metrics.go
+++ b/internal/subscriber/metrics.go
@@ -29,6 +29,8 @@ var (
 	subscriberNumberOfRetainedAckedMessages    *prometheus.GaugeVec
 	subscriberRetainedAckedMessagesSize        *prometheus.GaugeVec
 	subscriberLastMsgProcessingTime            *prometheus.GaugeVec
+	subscriberPartitionConsumerLag             *prometheus.GaugeVec
+	subscriberConsumerLag                      *prometheus.GaugeVec
 )
 
 func init() {
@@ -133,4 +135,12 @@ func init() {
 	subscriberLastMsgProcessingTime = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "metro_subscriber_identify_last_message_processing_time",
 	}, []string{"env", "topic", "subscription", "partition"})
+
+	subscriberPartitionConsumerLag = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "metro_subscriber_calculated_partition_consumer_lag",
+	}, []string{"env", "topic", "subscription", "partition"})
+
+	subscriberConsumerLag = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "metro_subscriber_calculated_consumer_lag",
+	}, []string{"env", "topic", "subscription"})
 }

--- a/internal/subscriber/ordering.go
+++ b/internal/subscriber/ordering.go
@@ -43,6 +43,16 @@ func (s *OrderedImplementation) GetSubscription() *subscription.Model {
 	return s.subscription
 }
 
+// GetConsumerLag returns preceived lag for the gievn Subscriber
+func (s *OrderedImplementation) GetConsumerLag() map[string]uint64 {
+
+	lag := make(map[string]uint64)
+
+	lag, _ = s.consumer.GetConsumerLag(s.ctx)
+
+	return lag
+}
+
 // CanConsumeMore looks at sum of all consumed messages in all the active topic partitions and checks threshold
 func (s *OrderedImplementation) CanConsumeMore() bool {
 	totalConsumedMsgsForTopic := 0

--- a/internal/subscriber/ordering.go
+++ b/internal/subscriber/ordering.go
@@ -43,7 +43,7 @@ func (s *OrderedImplementation) GetSubscription() *subscription.Model {
 	return s.subscription
 }
 
-// GetConsumerLag returns perceived lag for the gievn Subscriber
+// GetConsumerLag returns perceived lag for the given Subscriber
 func (s *OrderedImplementation) GetConsumerLag() map[string]uint64 {
 
 	lag, _ := s.consumer.GetConsumerLag(s.ctx)

--- a/internal/subscriber/ordering.go
+++ b/internal/subscriber/ordering.go
@@ -43,12 +43,10 @@ func (s *OrderedImplementation) GetSubscription() *subscription.Model {
 	return s.subscription
 }
 
-// GetConsumerLag returns preceived lag for the gievn Subscriber
+// GetConsumerLag returns perceived lag for the gievn Subscriber
 func (s *OrderedImplementation) GetConsumerLag() map[string]uint64 {
 
-	lag := make(map[string]uint64)
-
-	lag, _ = s.consumer.GetConsumerLag(s.ctx)
+	lag, _ := s.consumer.GetConsumerLag(s.ctx)
 
 	return lag
 }

--- a/internal/subscriber/subscriber.go
+++ b/internal/subscriber/subscriber.go
@@ -142,7 +142,7 @@ func (s *Subscriber) Run(ctx context.Context) {
 		case <-s.healthMonitorTicker.C:
 			lag := s.subscriberImpl.GetConsumerLag()
 			for topic, offset := range lag {
-				tp := strings.Split(topic, "-")
+				tp := strings.Split(topic, "=")
 				if len(tp) == 1 {
 					logger.Ctx(ctx).Errorw("subscriber: failed to parse topic and partition for consumer lag", "topic", topic)
 					continue

--- a/internal/subscriber/subscriber.go
+++ b/internal/subscriber/subscriber.go
@@ -143,7 +143,7 @@ func (s *Subscriber) Run(ctx context.Context) {
 			lag := s.subscriberImpl.GetConsumerLag()
 			for topic, offset := range lag {
 				tp := strings.Split(topic, "-")
-				if len(tp) != 2 {
+				if len(tp) == 1 {
 					logger.Ctx(ctx).Errorw("subscriber: failed to parse topic and partition for consumer lag", "topic", topic)
 					continue
 				}

--- a/internal/subscriber/subscriberimpl.go
+++ b/internal/subscriber/subscriberimpl.go
@@ -40,12 +40,10 @@ func (s *BasicImplementation) GetSubscription() *subscription.Model {
 	return s.subscription
 }
 
-// GetConsumerLag returns preceived lag for the gievn Subscriber
+// GetConsumerLag returns perceived lag for the gievn Subscriber
 func (s *BasicImplementation) GetConsumerLag() map[string]uint64 {
 
-	lag := make(map[string]uint64)
-
-	lag, _ = s.consumer.GetConsumerLag(s.ctx)
+	lag, _ := s.consumer.GetConsumerLag(s.ctx)
 
 	return lag
 }

--- a/internal/subscriber/subscriberimpl.go
+++ b/internal/subscriber/subscriberimpl.go
@@ -40,6 +40,16 @@ func (s *BasicImplementation) GetSubscription() *subscription.Model {
 	return s.subscription
 }
 
+// GetConsumerLag returns preceived lag for the gievn Subscriber
+func (s *BasicImplementation) GetConsumerLag() map[string]uint64 {
+
+	lag := make(map[string]uint64)
+
+	lag, _ = s.consumer.GetConsumerLag(s.ctx)
+
+	return lag
+}
+
 // CanConsumeMore looks at sum of all consumed messages in all the active topic partitions and checks threshold
 func (s *BasicImplementation) CanConsumeMore() bool {
 	totalConsumedMsgsForTopic := 0

--- a/internal/subscriber/subscriberimpl_test.go
+++ b/internal/subscriber/subscriberimpl_test.go
@@ -330,3 +330,33 @@ func getMockReceivedMessages(input []string) []messagebroker.ReceivedMessage {
 	}
 	return messages
 }
+
+func TestBasicImplementation_GetConsumerLag(t *testing.T) {
+	_, cs, subImpl := setup(t)
+	pTopic := subImpl.topic
+	rTopic := subImpl.subscription.GetRetryTopic()
+	tests := []struct {
+		name string
+		want map[string]uint64
+	}{
+		{
+			name: "Fetch consumer lag for consumer",
+			want: map[string]uint64{
+				pTopic: 0,
+				rTopic: 0,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cs.EXPECT().FetchConsumerLag(gomock.Any()).Return(map[string]uint64{
+				pTopic: 0,
+				rTopic: 0,
+			}, nil).Times(1)
+			got := subImpl.GetConsumerLag()
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("BasicImplementation.GetConsumerLag() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/messagebroker/kafka.go
+++ b/pkg/messagebroker/kafka.go
@@ -642,7 +642,7 @@ func (k *KafkaBroker) FetchConsumerLag(ctx context.Context) (map[string]uint64, 
 	}
 
 	for _, tp := range committed {
-		topicPart := *tp.Topic + "-" + strconv.Itoa(int(tp.Partition))
+		topicPart := *tp.Topic + "=" + strconv.Itoa(int(tp.Partition))
 		low, high, err := k.Consumer.QueryWatermarkOffsets(*tp.Topic, tp.Partition, kafkaMetadataTimeout)
 		if err != nil {
 			logger.Ctx(ctx).Errorw("kafka: failed to fetch watermark offsets",

--- a/pkg/messagebroker/kafka.go
+++ b/pkg/messagebroker/kafka.go
@@ -627,6 +627,7 @@ func (k *KafkaBroker) Resume(_ context.Context, request ResumeOnTopicRequest) er
 	return k.Consumer.Resume(tps)
 }
 
+// FetchConsumerLag calculates consumer lag for all assigned partitions
 func (k *KafkaBroker) FetchConsumerLag(ctx context.Context) (map[string]uint64, error) {
 	lag := make(map[string]uint64)
 

--- a/pkg/messagebroker/kafka.go
+++ b/pkg/messagebroker/kafka.go
@@ -645,7 +645,11 @@ func (k *KafkaBroker) FetchConsumerLag(ctx context.Context) (map[string]uint64, 
 		topicPart := *tp.Topic + "-" + strconv.Itoa(int(tp.Partition))
 		low, high, err := k.Consumer.QueryWatermarkOffsets(*tp.Topic, tp.Partition, kafkaMetadataTimeout)
 		if err != nil {
-			logger.Ctx(ctx).Errorw("kafka: failed to fetch watermark offsets", "error", err.Error(), "topic", tp.Topic, "partition", tp.Partition)
+			logger.Ctx(ctx).Errorw("kafka: failed to fetch watermark offsets",
+				"error", err.Error(),
+				"topic", tp.Topic,
+				"partition", tp.Partition,
+			)
 			continue
 		}
 		if tp.Offset == kafkapkg.OffsetInvalid {
@@ -653,7 +657,6 @@ func (k *KafkaBroker) FetchConsumerLag(ctx context.Context) (map[string]uint64, 
 		} else {
 			lag[topicPart] = uint64(high - int64(tp.Offset))
 		}
-
 	}
 	return lag, nil
 }

--- a/pkg/messagebroker/kafka.go
+++ b/pkg/messagebroker/kafka.go
@@ -642,15 +642,16 @@ func (k *KafkaBroker) FetchConsumerLag(ctx context.Context) (map[string]uint64, 
 	}
 
 	for _, tp := range committed {
+		topicPart := *tp.Topic + "-" + strconv.Itoa(int(tp.Partition))
 		low, high, err := k.Consumer.QueryWatermarkOffsets(*tp.Topic, tp.Partition, kafkaMetadataTimeout)
 		if err != nil {
 			logger.Ctx(ctx).Errorw("kafka: failed to fetch watermark offsets", "error", err.Error(), "topic", tp.Topic, "partition", tp.Partition)
 			continue
 		}
 		if tp.Offset == kafkapkg.OffsetInvalid {
-			lag[*tp.Topic] = uint64(high - low)
+			lag[topicPart] = uint64(high - low)
 		} else {
-			lag[*tp.Topic] = uint64(high - int64(tp.Offset))
+			lag[topicPart] = uint64(high - int64(tp.Offset))
 		}
 
 	}

--- a/pkg/messagebroker/kafka.go
+++ b/pkg/messagebroker/kafka.go
@@ -16,6 +16,7 @@ import (
 
 var (
 	errProducerUnavailable = errors.New("producer unavailable")
+	kafkaMetadataTimeout   = 1000
 )
 
 // KafkaBroker for kafka
@@ -624,6 +625,35 @@ func (k *KafkaBroker) Resume(_ context.Context, request ResumeOnTopicRequest) er
 	tps = append(tps, tp)
 
 	return k.Consumer.Resume(tps)
+}
+
+func (k *KafkaBroker) FetchConsumerLag(ctx context.Context) (map[string]uint64, error) {
+	lag := make(map[string]uint64)
+
+	assigned, err := k.Consumer.Assignment()
+	if err != nil {
+		return lag, err
+	}
+
+	committed, err := k.Consumer.Committed(assigned, kafkaMetadataTimeout)
+	if err != nil {
+		return lag, err
+	}
+
+	for _, tp := range committed {
+		low, high, err := k.Consumer.QueryWatermarkOffsets(*tp.Topic, tp.Partition, kafkaMetadataTimeout)
+		if err != nil {
+			logger.Ctx(ctx).Errorw("kafka: failed to fetch watermark offsets", "error", err.Error(), "topic", tp.Topic, "partition", tp.Partition)
+			continue
+		}
+		if tp.Offset == kafkapkg.OffsetInvalid {
+			lag[*tp.Topic] = uint64(high - low)
+		} else {
+			lag[*tp.Topic] = uint64(high - int64(tp.Offset))
+		}
+
+	}
+	return lag, nil
 }
 
 // Close closes the consumer

--- a/pkg/messagebroker/messagebroker.go
+++ b/pkg/messagebroker/messagebroker.go
@@ -60,6 +60,9 @@ type Consumer interface {
 	// Resume resume the consumer
 	Resume(context.Context, ResumeOnTopicRequest) error
 
+	// FetchConsumerLag returns the watermark and current offset for a consumer
+	FetchConsumerLag(context.Context) (map[string]uint64, error)
+
 	// Close closes the consumer
 	Close(context.Context) error
 }

--- a/pkg/messagebroker/pulsar.go
+++ b/pkg/messagebroker/pulsar.go
@@ -135,6 +135,13 @@ func newPulsarAdminClient(ctx context.Context, bConfig *BrokerConfig, options *A
 	}, nil
 }
 
+//FetchConsumerLag ...
+func (p *PulsarBroker) FetchConsumerLag(ctx context.Context) (map[string]uint64, error) {
+	lag := make(map[string]uint64)
+
+	return lag, nil
+}
+
 // CreateTopic creates a new topic if not available
 func (p *PulsarBroker) CreateTopic(ctx context.Context, request CreateTopicRequest) (CreateTopicResponse, error) {
 	messageBrokerOperationCount.WithLabelValues(env, Pulsar, "CreateTopic").Inc()


### PR DESCRIPTION
Using `-` as a separator for topic-partition conflicts with topic names which naturally use `-` 
Changing the separator to `=`