### PR TITLE
Introduce randomness in the scheduling algorithm even with load balancing

### DIFF
--- a/internal/scheduler/loadbalancealgoimpl.go
+++ b/internal/scheduler/loadbalancealgoimpl.go
@@ -2,7 +2,9 @@ package scheduler
 
 import (
 	"fmt"
+	"math/rand"
 	"sort"
+	"time"
 
 	"github.com/razorpay/metro/internal/node"
 	"github.com/razorpay/metro/internal/nodebinding"
@@ -48,6 +50,14 @@ func (algo *LoadBalanceAlgoImpl) GetNode(nodebindings []*nodebinding.Model, node
 			Count: v,
 		})
 	}
+
+	rand.Seed(time.Now().UnixNano())
+	rand.Shuffle(
+		len(nodeCountList),
+		func(i, j int) {
+			nodeCountList[i], nodeCountList[j] = nodeCountList[j], nodeCountList[i]
+		},
+	)
 
 	sort.Sort(nodeCountList)
 

--- a/internal/scheduler/loadbalancealgoimpl_test.go
+++ b/internal/scheduler/loadbalancealgoimpl_test.go
@@ -35,9 +35,9 @@ func TestLoadBalanceAlgoImpl_GetNode(t *testing.T) {
 
 	excludedNodes := []string{"node01", "node05"}
 
-	node, err := ai.GetNode(nbs, nodes)
+	schedulingNode, err := ai.GetNode(nbs, nodes)
 	assert.Nil(t, err)
-	assert.NotNil(t, node)
-	assert.NotContains(t, excludedNodes, node.ID)
-	assert.Contains(t, nodeNames, node.ID)
+	assert.NotNil(t, schedulingNode)
+	assert.NotContains(t, excludedNodes, schedulingNode.ID)
+	assert.Contains(t, nodeNames, schedulingNode.ID)
 }

--- a/internal/scheduler/loadbalancealgoimpl_test.go
+++ b/internal/scheduler/loadbalancealgoimpl_test.go
@@ -1,0 +1,43 @@
+package scheduler
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/razorpay/metro/internal/node"
+	"github.com/razorpay/metro/internal/nodebinding"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoadBalanceAlgoImpl_GetNode(t *testing.T) {
+	ai, err := GetAlgorithmImpl(LoadBalance)
+	assert.Nil(t, err)
+	assert.NotNil(t, ai)
+
+	nbs := []*nodebinding.Model{
+		{
+			ID:             uuid.New().String(),
+			SubscriptionID: "sub1",
+			NodeID:         "node01",
+		},
+		{
+			ID:             uuid.New().String(),
+			SubscriptionID: "sub2",
+			NodeID:         "node05",
+		},
+	}
+
+	nodeNames := []string{"node01", "node02", "node03", "node04", "node05", "node06"}
+	nodes := make(map[string]*node.Model, len(nodeNames))
+	for _, nodeName := range nodeNames {
+		nodes[nodeName] = &node.Model{ID: nodeName}
+	}
+
+	excludedNodes := []string{"node01", "node05"}
+
+	node, err := ai.GetNode(nbs, nodes)
+	assert.Nil(t, err)
+	assert.NotNil(t, node)
+	assert.NotContains(t, excludedNodes, node.ID)
+	assert.Contains(t, nodeNames, node.ID)
+}

--- a/internal/subscription/model.go
+++ b/internal/subscription/model.go
@@ -20,9 +20,6 @@ const (
 	SubscriptionTypePull = "Pull"
 )
 
-// List of subscription model
-type List []*Model
-
 // Model for a subscription
 type Model struct {
 	common.BaseModel

--- a/internal/subscription/model.go
+++ b/internal/subscription/model.go
@@ -20,7 +20,8 @@ const (
 	SubscriptionTypePull = "Pull"
 )
 
-type SubscriptionList []*Model
+// List of subscription model
+type List []*Model
 
 // Model for a subscription
 type Model struct {

--- a/internal/subscription/model.go
+++ b/internal/subscription/model.go
@@ -20,6 +20,8 @@ const (
 	SubscriptionTypePull = "Pull"
 )
 
+type SubscriptionList []*Model
+
 // Model for a subscription
 type Model struct {
 	common.BaseModel

--- a/internal/tasks/schedulertask.go
+++ b/internal/tasks/schedulertask.go
@@ -2,7 +2,9 @@ package tasks
 
 import (
 	"context"
+	"math/rand"
 	"strconv"
+	"time"
 
 	"golang.org/x/sync/errgroup"
 
@@ -361,7 +363,20 @@ func (sm *SchedulerTask) refreshNodeBindings(ctx context.Context) error {
 		validBindings[subPart] = nb
 	}
 
+	validSubscriptions := subscription.SubscriptionList{}
 	for _, sub := range sm.subCache {
+		validSubscriptions = append(validSubscriptions, sub)
+	}
+
+	rand.Seed(time.Now().UnixNano())
+	rand.Shuffle(
+		len(validSubscriptions),
+		func(i, j int) {
+			validSubscriptions[i], validSubscriptions[j] = validSubscriptions[j], validSubscriptions[i]
+		},
+	)
+
+	for _, sub := range validSubscriptions {
 		//Fetch topic and see if all partitions are assigned.
 		// If not assign missing ones
 		topic, ok := sm.topicCache[sub.Topic]

--- a/internal/tasks/schedulertask.go
+++ b/internal/tasks/schedulertask.go
@@ -363,7 +363,7 @@ func (sm *SchedulerTask) refreshNodeBindings(ctx context.Context) error {
 		validBindings[subPart] = nb
 	}
 
-	validSubscriptions := subscription.List{}
+	validSubscriptions := make([]*subscription.Model, 0, len(validBindings))
 	for _, sub := range sm.subCache {
 		validSubscriptions = append(validSubscriptions, sub)
 	}

--- a/internal/tasks/schedulertask.go
+++ b/internal/tasks/schedulertask.go
@@ -363,7 +363,7 @@ func (sm *SchedulerTask) refreshNodeBindings(ctx context.Context) error {
 		validBindings[subPart] = nb
 	}
 
-	validSubscriptions := subscription.SubscriptionList{}
+	validSubscriptions := subscription.List{}
 	for _, sub := range sm.subCache {
 		validSubscriptions = append(validSubscriptions, sub)
 	}


### PR DESCRIPTION
# Description
Today, node bindings refresh end up with the same old bindings because we are assigning subscriptions one by one to the same set of nodes in round robin fashion. To solve for that, going forward, we will
1. Shuffle the subscriptions array before scheduling
2. We will shuffle nodes array before picking up the least loaded node

Fixes https://razorpay.atlassian.net/browse/METRO-112

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
- [x] I triggered node binding refresh multiple times to see if subscriptions get assigned to same nodes or not on both local and stage. 
- [x] I checked if the existing functionality of assigning all subscriptions to node acc to the load is intact.

# Is it a breaking change?
No

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added integration tests for the new feature (if applicable)
- [x] I have manually tested my code to the best of my abilities.
