### PR TITLE
Redacted password in url while logging/metrics

### DIFF
--- a/internal/stream/processor.go
+++ b/internal/stream/processor.go
@@ -117,13 +117,13 @@ func (pr *processor) pushMessage(ctx context.Context, message *metrov1.ReceivedM
 			opentracing.HTTPHeadersCarrier(req.Header))
 	}
 
-	logFields["endpoint"] = subModel.PushConfig.GetRedactedPushEndpoint()
+	logFields["endpoint"] = subModel.GetRedactedPushEndpoint()
 	logger.Ctx(ctx).Infow("worker: posting messages to subscription url", "logFields", logFields)
 	resp, err := pr.httpClient.Do(req)
 
 	// log metrics
-	workerPushEndpointCallsCount.WithLabelValues(env, subModel.Topic, subModel.Name, subModel.PushConfig.GetRedactedPushEndpoint(), pr.subID).Inc()
-	workerPushEndpointTimeTaken.WithLabelValues(env, subModel.Topic, subModel.Name, subModel.PushConfig.GetRedactedPushEndpoint()).Observe(time.Now().Sub(startTime).Seconds())
+	workerPushEndpointCallsCount.WithLabelValues(env, subModel.Topic, subModel.Name, subModel.GetRedactedPushEndpoint(), pr.subID).Inc()
+	workerPushEndpointTimeTaken.WithLabelValues(env, subModel.Topic, subModel.Name, subModel.GetRedactedPushEndpoint()).Observe(time.Now().Sub(startTime).Seconds())
 
 	// Process responnse
 	if err != nil {
@@ -132,7 +132,7 @@ func (pr *processor) pushMessage(ctx context.Context, message *metrov1.ReceivedM
 	}
 
 	logger.Ctx(pr.ctx).Infow("worker: push response received for subscription", "status", resp.StatusCode, "logFields", logFields)
-	workerPushEndpointHTTPStatusCode.WithLabelValues(env, subModel.Topic, subModel.Name, subModel.PushConfig.GetRedactedPushEndpoint(), fmt.Sprintf("%v", resp.StatusCode)).Inc()
+	workerPushEndpointHTTPStatusCode.WithLabelValues(env, subModel.Topic, subModel.Name, subModel.GetRedactedPushEndpoint(), fmt.Sprintf("%v", resp.StatusCode)).Inc()
 
 	success := false
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {

--- a/internal/stream/processor.go
+++ b/internal/stream/processor.go
@@ -117,13 +117,13 @@ func (pr *processor) pushMessage(ctx context.Context, message *metrov1.ReceivedM
 			opentracing.HTTPHeadersCarrier(req.Header))
 	}
 
-	logFields["endpoint"] = subModel.PushConfig.PushEndpoint
+	logFields["endpoint"] = subModel.PushConfig.GetRedactedPushEndpoint()
 	logger.Ctx(ctx).Infow("worker: posting messages to subscription url", "logFields", logFields)
 	resp, err := pr.httpClient.Do(req)
 
 	// log metrics
-	workerPushEndpointCallsCount.WithLabelValues(env, subModel.Topic, subModel.Name, subModel.PushConfig.PushEndpoint, pr.subID).Inc()
-	workerPushEndpointTimeTaken.WithLabelValues(env, subModel.Topic, subModel.Name, subModel.PushConfig.PushEndpoint).Observe(time.Now().Sub(startTime).Seconds())
+	workerPushEndpointCallsCount.WithLabelValues(env, subModel.Topic, subModel.Name, subModel.PushConfig.GetRedactedPushEndpoint(), pr.subID).Inc()
+	workerPushEndpointTimeTaken.WithLabelValues(env, subModel.Topic, subModel.Name, subModel.PushConfig.GetRedactedPushEndpoint()).Observe(time.Now().Sub(startTime).Seconds())
 
 	// Process responnse
 	if err != nil {
@@ -132,7 +132,7 @@ func (pr *processor) pushMessage(ctx context.Context, message *metrov1.ReceivedM
 	}
 
 	logger.Ctx(pr.ctx).Infow("worker: push response received for subscription", "status", resp.StatusCode, "logFields", logFields)
-	workerPushEndpointHTTPStatusCode.WithLabelValues(env, subModel.Topic, subModel.Name, subModel.PushConfig.PushEndpoint, fmt.Sprintf("%v", resp.StatusCode)).Inc()
+	workerPushEndpointHTTPStatusCode.WithLabelValues(env, subModel.Topic, subModel.Name, subModel.PushConfig.GetRedactedPushEndpoint(), fmt.Sprintf("%v", resp.StatusCode)).Inc()
 
 	success := false
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {

--- a/internal/stream/stream.go
+++ b/internal/stream/stream.go
@@ -249,7 +249,7 @@ func (ps *PushStream) nack(ctx context.Context, message *metrov1.ReceivedMessage
 		env,
 		ps.subscription.Topic,
 		ps.subscription.Name,
-		ps.subscription.PushConfig.GetRedactedPushEndpoint(),
+		ps.subscription.GetRedactedPushEndpoint(),
 		ps.subs.GetID(),
 	).Inc()
 
@@ -284,7 +284,7 @@ func (ps *PushStream) ack(ctx context.Context, message *metrov1.ReceivedMessage)
 		env,
 		ps.subscription.Topic,
 		ps.subscription.Name,
-		ps.subscription.PushConfig.GetRedactedPushEndpoint(),
+		ps.subscription.GetRedactedPushEndpoint(),
 		ps.subs.GetID(),
 	).Inc()
 

--- a/internal/stream/stream.go
+++ b/internal/stream/stream.go
@@ -249,7 +249,7 @@ func (ps *PushStream) nack(ctx context.Context, message *metrov1.ReceivedMessage
 		env,
 		ps.subscription.Topic,
 		ps.subscription.Name,
-		ps.subscription.PushConfig.PushEndpoint,
+		ps.subscription.PushConfig.GetRedactedPushEndpoint(),
 		ps.subs.GetID(),
 	).Inc()
 
@@ -284,7 +284,7 @@ func (ps *PushStream) ack(ctx context.Context, message *metrov1.ReceivedMessage)
 		env,
 		ps.subscription.Topic,
 		ps.subscription.Name,
-		ps.subscription.PushConfig.PushEndpoint,
+		ps.subscription.PushConfig.GetRedactedPushEndpoint(),
 		ps.subs.GetID(),
 	).Inc()
 

--- a/internal/subscription/model.go
+++ b/internal/subscription/model.go
@@ -55,6 +55,7 @@ type PushConfig struct {
 	Credentials  *credentials.Model `json:"credentials,omitempty"`
 }
 
+// GetRedactedPushEndpoint returns the push endpoint but replaces any password with "xxxxx".
 func (pc *PushConfig) GetRedactedPushEndpoint() string {
 	if url, err := url.Parse(pc.PushEndpoint); err == nil {
 		return url.Redacted()

--- a/internal/subscription/model.go
+++ b/internal/subscription/model.go
@@ -2,7 +2,7 @@ package subscription
 
 import (
 	"fmt"
-	"net/url"
+	urlpkg "net/url"
 
 	"github.com/razorpay/metro/internal/common"
 	"github.com/razorpay/metro/internal/credentials"
@@ -56,9 +56,11 @@ type PushConfig struct {
 }
 
 // GetRedactedPushEndpoint returns the push endpoint but replaces any password with "xxxxx".
-func (pc *PushConfig) GetRedactedPushEndpoint() string {
-	if url, err := url.Parse(pc.PushEndpoint); err == nil {
-		return url.Redacted()
+func (m *Model) GetRedactedPushEndpoint() string {
+	if m.IsPush() {
+		if url, err := urlpkg.Parse(m.PushConfig.PushEndpoint); err == nil {
+			return url.Redacted()
+		}
 	}
 	return ""
 }

--- a/internal/subscription/model.go
+++ b/internal/subscription/model.go
@@ -58,7 +58,7 @@ type PushConfig struct {
 // GetRedactedPushEndpoint returns the push endpoint but replaces any password with "xxxxx".
 func (m *Model) GetRedactedPushEndpoint() string {
 	if m.IsPush() {
-		if url, err := urlpkg.Parse(m.PushConfig.PushEndpoint); err == nil {
+		if url, err := urlpkg.ParseRequestURI(m.PushConfig.PushEndpoint); err == nil {
 			return url.Redacted()
 		}
 	}

--- a/internal/subscription/model.go
+++ b/internal/subscription/model.go
@@ -2,6 +2,7 @@ package subscription
 
 import (
 	"fmt"
+	"net/url"
 
 	"github.com/razorpay/metro/internal/common"
 	"github.com/razorpay/metro/internal/credentials"
@@ -52,6 +53,13 @@ type PushConfig struct {
 	PushEndpoint string             `json:"push_endpoint,omitempty"`
 	Attributes   map[string]string  `json:"attributes,omitempty"`
 	Credentials  *credentials.Model `json:"credentials,omitempty"`
+}
+
+func (pc *PushConfig) GetRedactedPushEndpoint() string {
+	if url, err := url.Parse(pc.PushEndpoint); err == nil {
+		return url.Redacted()
+	}
+	return ""
 }
 
 // RetryPolicy defines the retry policy

--- a/internal/subscription/model_test.go
+++ b/internal/subscription/model_test.go
@@ -62,6 +62,7 @@ func Test_Model(t *testing.T) {
 	assert.False(t, dSubscription.IsPush())
 	assert.Nil(t, dSubscription.GetCredentials())
 	assert.False(t, dSubscription.HasCredentials())
+	assert.Empty(t, dSubscription.GetRedactedPushEndpoint())
 
 	dSubscription.setDefaultRetryPolicy()
 	assert.Equal(t, uint(5), dSubscription.RetryPolicy.MinimumBackoff)

--- a/internal/subscription/model_test.go
+++ b/internal/subscription/model_test.go
@@ -91,6 +91,14 @@ func TestModel_GetRedactedPushEndpoint(t *testing.T) {
 			assert: assert.Equal,
 		},
 		{
+			url:    "https://google.com/search?a=123&b=123",
+			assert: assert.Equal,
+		},
+		{
+			url:    "http//google.com/search?a=123",
+			assert: assert.NotEqual,
+		},
+		{
 			url:    "https://username:password@google.com",
 			assert: assert.NotEqual,
 		},
@@ -98,6 +106,7 @@ func TestModel_GetRedactedPushEndpoint(t *testing.T) {
 	sub := getDummySubscriptionModel()
 	for _, test := range tests {
 		sub.PushConfig.PushEndpoint = test.url
-		test.assert(t, test.url, sub.GetRedactedPushEndpoint())
+		got := sub.GetRedactedPushEndpoint()
+		test.assert(t, test.url, got)
 	}
 }

--- a/internal/subscription/model_test.go
+++ b/internal/subscription/model_test.go
@@ -6,10 +6,8 @@ package subscription
 import (
 	"testing"
 
-	"github.com/razorpay/metro/internal/credentials"
-
 	"github.com/razorpay/metro/internal/common"
-
+	"github.com/razorpay/metro/internal/credentials"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -62,7 +60,6 @@ func Test_Model(t *testing.T) {
 	assert.False(t, dSubscription.IsPush())
 	assert.Nil(t, dSubscription.GetCredentials())
 	assert.False(t, dSubscription.HasCredentials())
-	assert.Empty(t, dSubscription.GetRedactedPushEndpoint())
 
 	dSubscription.setDefaultRetryPolicy()
 	assert.Equal(t, uint(5), dSubscription.RetryPolicy.MinimumBackoff)
@@ -82,4 +79,25 @@ func Test_Model(t *testing.T) {
 
 	assert.Equal(t, "test-subscription.delay.5.seconds-cg", dSubscription.GetDelayConsumerGroupID("test-subscription.delay.5.seconds"))
 	assert.Equal(t, "test-subscription.delay.5.seconds-subscriberID", dSubscription.GetDelayConsumerGroupInstanceID("subscriberID", "test-subscription.delay.5.seconds"))
+}
+
+func TestModel_GetRedactedPushEndpoint(t *testing.T) {
+	tests := []struct {
+		url    string
+		assert func(assert.TestingT, interface{}, interface{}, ...interface{}) bool
+	}{
+		{
+			url:    "https://google.com/",
+			assert: assert.Equal,
+		},
+		{
+			url:    "https://username:password@google.com",
+			assert: assert.NotEqual,
+		},
+	}
+	sub := getDummySubscriptionModel()
+	for _, test := range tests {
+		sub.PushConfig.PushEndpoint = test.url
+		test.assert(t, test.url, sub.GetRedactedPushEndpoint())
+	}
 }

--- a/service/web/subscriberserver.go
+++ b/service/web/subscriberserver.go
@@ -302,5 +302,6 @@ func (s subscriberserver) GetSubscription(ctx context.Context, req *metrov1.GetS
 	if subs.IsPush() && subs.PushConfig.Credentials != nil {
 		subs.PushConfig.Credentials.Password = ""
 	}
+	subs.PushConfig.PushEndpoint = subs.PushConfig.GetRedactedPushEndpoint()
 	return subscription.ModelToSubscriptionProtoV1(subs), nil
 }

--- a/service/web/subscriberserver.go
+++ b/service/web/subscriberserver.go
@@ -302,6 +302,6 @@ func (s subscriberserver) GetSubscription(ctx context.Context, req *metrov1.GetS
 	if subs.IsPush() && subs.PushConfig.Credentials != nil {
 		subs.PushConfig.Credentials.Password = ""
 	}
-	subs.PushConfig.PushEndpoint = subs.PushConfig.GetRedactedPushEndpoint()
+	subs.PushConfig.PushEndpoint = subs.GetRedactedPushEndpoint()
 	return subscription.ModelToSubscriptionProtoV1(subs), nil
 }


### PR DESCRIPTION
# Description
Redacted password in url while logging/metrics

## Type of change
- [x] Security fix 

# How Has This Been Tested?

- [x] Tested GetSubscription api on local/stage
- [x] Verified existing worker flow, and push endpoint logs
- [ ] Verified push endpoint label on grafana

# Is it a breaking change?
No

## Screenshots:
<img width="788" alt="Screenshot 2022-08-29 at 1 41 33 PM" src="https://user-images.githubusercontent.com/104060154/187155356-1dfafec4-4618-4666-bf3e-15b7188e9ae8.png">
<img width="1173" alt="Screenshot 2022-08-29 at 1 41 52 PM" src="https://user-images.githubusercontent.com/104060154/187155422-dc1d79dc-f6bc-4957-983e-0beed02fb39b.png">

# Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added integration tests for the new feature (if applicable)
- [x] I have manually tested my code to the best of my abilities.
