### PR TITLE
Set retention policy while dlq topic creation

### DIFF
--- a/internal/topic/core.go
+++ b/internal/topic/core.go
@@ -285,10 +285,11 @@ func (c *Core) List(ctx context.Context, prefix string) ([]*Model, error) {
 }
 
 func (c *Core) getRetentionConfig(model *Model) map[string]string {
-	configs := make(map[string]string, 2)
 	if model.IsDeadLetterTopic() {
-		configs["retention.ms"] = fmt.Sprint(retentionPeriod)
-		configs["retention.bytes"] = fmt.Sprint(retentionSizePerPartition * model.NumPartitions)
+		return map[string]string{
+			"retention.ms":    fmt.Sprint(retentionPeriod),
+			"retention.bytes": fmt.Sprint(retentionSizePerPartition * model.NumPartitions),
+		}
 	}
-	return configs
+	return nil
 }

--- a/internal/topic/core.go
+++ b/internal/topic/core.go
@@ -2,7 +2,6 @@ package topic
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/opentracing/opentracing-go"
@@ -13,9 +12,6 @@ import (
 	"github.com/razorpay/metro/pkg/logger"
 	"github.com/razorpay/metro/pkg/messagebroker"
 )
-
-const retentionPeriod = 1000 * 60 * 60 * 24 * 3   // 3 days
-const retentionSizePerPartition = 10000 * 1000000 // 10000 MB ~ 10000 messages
 
 // ICore is an interface over topic core
 type ICore interface {
@@ -255,7 +251,7 @@ func (c *Core) createBrokerTopic(ctx context.Context, model *Model) error {
 	_, terr := admin.CreateTopic(ctx, messagebroker.CreateTopicRequest{
 		Name:          model.Name,
 		NumPartitions: model.NumPartitions,
-		Config:        c.getRetentionConfig(model),
+		Config:        model.GetRetentionConfig(),
 	})
 
 	return terr
@@ -282,14 +278,4 @@ func (c *Core) List(ctx context.Context, prefix string) ([]*Model, error) {
 		out = append(out, obj.(*Model))
 	}
 	return out, nil
-}
-
-func (c *Core) getRetentionConfig(model *Model) map[string]string {
-	if model.IsDeadLetterTopic() {
-		return map[string]string{
-			"retention.ms":    fmt.Sprint(retentionPeriod),
-			"retention.bytes": fmt.Sprint(retentionSizePerPartition * model.NumPartitions),
-		}
-	}
-	return nil
 }

--- a/internal/topic/core_test.go
+++ b/internal/topic/core_test.go
@@ -32,7 +32,7 @@ func TestCore_CreateTopic(t *testing.T) {
 	dTopic := getDummyTopicModel()
 	mockProjectCore.EXPECT().ExistsWithID(gomock.Any(), dTopic.ExtractedProjectID).Return(true, nil)
 	mockBrokerStore.EXPECT().GetAdmin(gomock.Any(), messagebroker.AdminClientOptions{}).Return(mockAdmin, nil)
-	mockAdmin.EXPECT().CreateTopic(gomock.Any(), messagebroker.CreateTopicRequest{dTopic.Name, DefaultNumPartitions}).Return(messagebroker.CreateTopicResponse{}, nil)
+	mockAdmin.EXPECT().CreateTopic(gomock.Any(), messagebroker.CreateTopicRequest{Name: dTopic.Name, NumPartitions: DefaultNumPartitions}).Return(messagebroker.CreateTopicResponse{}, nil)
 	mockTopicRepo.EXPECT().Exists(gomock.Any(), common.GetBasePrefix()+"topics/test-project/test-topic")
 	mockTopicRepo.EXPECT().Save(gomock.Any(), dTopic)
 	err := topicCore.CreateTopic(ctx, dTopic)
@@ -119,7 +119,7 @@ func TestCore_CreateSubscriptionTopic(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockBrokerStore.EXPECT().GetAdmin(gomock.AssignableToTypeOf(ctx), messagebroker.AdminClientOptions{}).Return(mockAdmin, nil)
-			mockAdmin.EXPECT().CreateTopic(gomock.AssignableToTypeOf(ctx), messagebroker.CreateTopicRequest{dTopic.Name, DefaultNumPartitions}).Return(messagebroker.CreateTopicResponse{}, nil)
+			mockAdmin.EXPECT().CreateTopic(gomock.AssignableToTypeOf(ctx), messagebroker.CreateTopicRequest{Name: dTopic.Name, NumPartitions: DefaultNumPartitions}).Return(messagebroker.CreateTopicResponse{}, nil)
 			if err := c.CreateSubscriptionTopic(tt.args.ctx, tt.args.model); (err != nil) != tt.wantErr {
 				t.Errorf("Core.CreateSubscriptionTopic() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/internal/topic/model.go
+++ b/internal/topic/model.go
@@ -30,7 +30,7 @@ const (
 	RetentionPeriodConfig = "retention.ms"
 
 	// RetentionPeriod is the time after which messages will be deleted from the topic = 3 days
-	RetentionPeriod = 1000 * 60 * 60 * 24 * 3
+	RetentionPeriod = 1000 * 60 * 60 * 24 * 14
 
 	// RetentionSizeConfig is the name of topic level retention by size config property
 	RetentionSizeConfig = "retention.bytes"

--- a/internal/topic/model.go
+++ b/internal/topic/model.go
@@ -26,16 +26,16 @@ const (
 	// MaxNumPartitions max number of partitions for a topic
 	MaxNumPartitions = 100
 
-	// RetentionPeriodConfig is the name of topic level retention period config property
+	// RetentionPeriodConfig is the topic level retention period config
 	RetentionPeriodConfig = "retention.ms"
 
 	// RetentionPeriod is the time after which messages will be deleted from the topic = 14 days
 	RetentionPeriod = 1000 * 60 * 60 * 24 * 14
 
-	// RetentionSizeConfig is the name of topic level retention by size configgit checkout -b METRO-151-existing-dlq-topics property
+	// RetentionSizeConfig is the partition retention size config
 	RetentionSizeConfig = "retention.bytes"
 
-	// RetentionSizePerPartition is the max no of bytes retained per topic = 10000MB
+	// RetentionSizePerPartition is the max no of bytes retained per partition = 10000MB
 	RetentionSizePerPartition = 10000 * 1000000
 )
 

--- a/internal/topic/model.go
+++ b/internal/topic/model.go
@@ -35,7 +35,7 @@ const (
 	// RetentionSizeConfig is the name of topic level retention by size config property
 	RetentionSizeConfig = "retention.bytes"
 
-	// RetentionSizePerPartition is the max no of bytes retained per topic partition = 10000MB
+	// RetentionSizePerPartition is the max no of bytes retained per topic = 10000MB
 	RetentionSizePerPartition = 10000 * 1000000
 )
 
@@ -90,7 +90,7 @@ func (m *Model) GetRetentionConfig() map[string]string {
 	if m.IsDeadLetterTopic() {
 		return map[string]string{
 			RetentionPeriodConfig: fmt.Sprint(RetentionPeriod),
-			RetentionSizeConfig:   fmt.Sprint(RetentionSizePerPartition * m.NumPartitions),
+			RetentionSizeConfig:   fmt.Sprint(RetentionSizePerPartition),
 		}
 	}
 	return nil

--- a/internal/topic/model.go
+++ b/internal/topic/model.go
@@ -79,6 +79,7 @@ func (m *Model) IsPrimaryTopic() bool {
 	return !m.IsDeadLetterTopic() && !m.IsDelayTopic() && !m.IsRetryTopic()
 }
 
+// GetRetentionConfig returns the retention policy for a given topic
 func (m *Model) GetRetentionConfig() map[string]string {
 	if m.IsDeadLetterTopic() {
 		return map[string]string{

--- a/internal/topic/model.go
+++ b/internal/topic/model.go
@@ -26,10 +26,10 @@ const (
 	// MaxNumPartitions max number of partitions for a topic
 	MaxNumPartitions = 100
 
-	// 3 days retention period
+	// RetentionPeriod is the time after which messages will be deleted from the topic = 3 days
 	RetentionPeriod = 1000 * 60 * 60 * 24 * 3
 
-	// 10000 MB retention size per partition ~ 10000 messages
+	// RetentionSizePerPartition is the max no of bytes retained per topic partition = 10000MB
 	RetentionSizePerPartition = 10000 * 1000000
 )
 

--- a/internal/topic/model.go
+++ b/internal/topic/model.go
@@ -29,10 +29,10 @@ const (
 	// RetentionPeriodConfig is the name of topic level retention period config property
 	RetentionPeriodConfig = "retention.ms"
 
-	// RetentionPeriod is the time after which messages will be deleted from the topic = 3 days
+	// RetentionPeriod is the time after which messages will be deleted from the topic = 14 days
 	RetentionPeriod = 1000 * 60 * 60 * 24 * 14
 
-	// RetentionSizeConfig is the name of topic level retention by size config property
+	// RetentionSizeConfig is the name of topic level retention by size configgit checkout -b METRO-151-existing-dlq-topics property
 	RetentionSizeConfig = "retention.bytes"
 
 	// RetentionSizePerPartition is the max no of bytes retained per topic = 10000MB

--- a/internal/topic/model.go
+++ b/internal/topic/model.go
@@ -26,8 +26,14 @@ const (
 	// MaxNumPartitions max number of partitions for a topic
 	MaxNumPartitions = 100
 
+	// RetentionPeriodConfig is the name of topic level retention period config property
+	RetentionPeriodConfig = "retention.ms"
+
 	// RetentionPeriod is the time after which messages will be deleted from the topic = 3 days
 	RetentionPeriod = 1000 * 60 * 60 * 24 * 3
+
+	// RetentionSizeConfig is the name of topic level retention by size config property
+	RetentionSizeConfig = "retention.bytes"
 
 	// RetentionSizePerPartition is the max no of bytes retained per topic partition = 10000MB
 	RetentionSizePerPartition = 10000 * 1000000
@@ -83,8 +89,8 @@ func (m *Model) IsPrimaryTopic() bool {
 func (m *Model) GetRetentionConfig() map[string]string {
 	if m.IsDeadLetterTopic() {
 		return map[string]string{
-			"retention.ms":    fmt.Sprint(RetentionPeriod),
-			"retention.bytes": fmt.Sprint(RetentionSizePerPartition * m.NumPartitions),
+			RetentionPeriodConfig: fmt.Sprint(RetentionPeriod),
+			RetentionSizeConfig:   fmt.Sprint(RetentionSizePerPartition * m.NumPartitions),
 		}
 	}
 	return nil

--- a/internal/topic/model.go
+++ b/internal/topic/model.go
@@ -25,6 +25,12 @@ const (
 
 	// MaxNumPartitions max number of partitions for a topic
 	MaxNumPartitions = 100
+
+	// 3 days retention period
+	RetentionPeriod = 1000 * 60 * 60 * 24 * 3
+
+	// 10000 MB retention size per partition ~ 10000 messages
+	RetentionSizePerPartition = 10000 * 1000000
 )
 
 // Model for a topic
@@ -71,4 +77,14 @@ func (m *Model) IsRetryTopic() bool {
 // IsPrimaryTopic checks if the topic is primary topic or not
 func (m *Model) IsPrimaryTopic() bool {
 	return !m.IsDeadLetterTopic() && !m.IsDelayTopic() && !m.IsRetryTopic()
+}
+
+func (m *Model) GetRetentionConfig() map[string]string {
+	if m.IsDeadLetterTopic() {
+		return map[string]string{
+			"retention.ms":    fmt.Sprint(RetentionPeriod),
+			"retention.bytes": fmt.Sprint(RetentionSizePerPartition * m.NumPartitions),
+		}
+	}
+	return nil
 }

--- a/internal/topic/model_test.go
+++ b/internal/topic/model_test.go
@@ -19,6 +19,16 @@ func getDummyTopicModel() *Model {
 	}
 }
 
+func getDLQDummyTopicModel() *Model {
+	return &Model{
+		Name:               "projects/test-project/topics/test-topic-dlq",
+		Labels:             map[string]string{"label": "value"},
+		ExtractedProjectID: "test-project",
+		ExtractedTopicName: "test-topic-dlq",
+		NumPartitions:      DefaultNumPartitions,
+	}
+}
+
 func TestModel_Prefix(t *testing.T) {
 	dTopic := getDummyTopicModel()
 	assert.Equal(t, common.GetBasePrefix()+Prefix+dTopic.ExtractedProjectID+"/", dTopic.Prefix())

--- a/pkg/messagebroker/kafka.go
+++ b/pkg/messagebroker/kafka.go
@@ -260,6 +260,10 @@ func (k *KafkaBroker) CreateTopic(ctx context.Context, request CreateTopicReques
 		ReplicationFactor: (len(k.Config.Brokers) + 1) / 2, // 50% of the available brokers
 	}
 
+	if len(request.Config) > 0 {
+		ts.Config = request.Config
+	}
+
 	topics = append(topics, ts)
 	topicsResp, err := k.Admin.CreateTopics(ctx, topics, kafkapkg.SetAdminOperationTimeout(59*time.Second))
 	if err != nil {

--- a/pkg/messagebroker/kafka.go
+++ b/pkg/messagebroker/kafka.go
@@ -260,7 +260,7 @@ func (k *KafkaBroker) CreateTopic(ctx context.Context, request CreateTopicReques
 		ReplicationFactor: (len(k.Config.Brokers) + 1) / 2, // 50% of the available brokers
 	}
 
-	if len(request.Config) > 0 {
+	if request.Config != nil && len(request.Config) > 0 {
 		ts.Config = request.Config
 	}
 

--- a/pkg/messagebroker/models.go
+++ b/pkg/messagebroker/models.go
@@ -10,6 +10,7 @@ import (
 type CreateTopicRequest struct {
 	Name          string
 	NumPartitions int
+	Config        map[string]string
 }
 
 // AddTopicPartitionRequest ...

--- a/tests/integration/messagebroker/messagebroker_kafka_test.go
+++ b/tests/integration/messagebroker/messagebroker_kafka_test.go
@@ -314,7 +314,7 @@ func Test_ResetAutoOffsetForConsumer(t *testing.T) {
 	aresp, err := admin.CreateTopic(context.Background(), messagebroker.CreateTopicRequest{
 		Name:          topic,
 		NumPartitions: 1,
-		Config: map[string]string{"retention.ms": 10000}
+		Config:        map[string]string{"retention.ms": "10000"},
 	})
 
 	assert.Nil(t, err)

--- a/tests/integration/messagebroker/messagebroker_kafka_test.go
+++ b/tests/integration/messagebroker/messagebroker_kafka_test.go
@@ -314,6 +314,7 @@ func Test_ResetAutoOffsetForConsumer(t *testing.T) {
 	aresp, err := admin.CreateTopic(context.Background(), messagebroker.CreateTopicRequest{
 		Name:          topic,
 		NumPartitions: 1,
+		Config: map[string]string{"retention.ms": 10000}
 	})
 
 	assert.Nil(t, err)

--- a/tests/integration/messagebroker/messagebroker_kafka_test.go
+++ b/tests/integration/messagebroker/messagebroker_kafka_test.go
@@ -314,7 +314,7 @@ func Test_ResetAutoOffsetForConsumer(t *testing.T) {
 	aresp, err := admin.CreateTopic(context.Background(), messagebroker.CreateTopicRequest{
 		Name:          topic,
 		NumPartitions: 1,
-		Config:        map[string]string{"retention.ms": "10000"},
+		Config:        map[string]string{RetentionPeriodConfig: "10000", RetentionSizeConfig: "1000"},
 	})
 
 	assert.Nil(t, err)

--- a/tests/integration/messagebroker/messagebroker_kafka_test.go
+++ b/tests/integration/messagebroker/messagebroker_kafka_test.go
@@ -314,7 +314,7 @@ func Test_ResetAutoOffsetForConsumer(t *testing.T) {
 	aresp, err := admin.CreateTopic(context.Background(), messagebroker.CreateTopicRequest{
 		Name:          topic,
 		NumPartitions: 1,
-		Config:        map[string]string{RetentionPeriodConfig: "10000", RetentionSizeConfig: "1000"},
+		Config:        map[string]string{"retention.ms": "10000", "retention.bytes": "1000"},
 	})
 
 	assert.Nil(t, err)


### PR DESCRIPTION
# Description
Set up retention policy for newly created dlq topics

Fixes https://razorpay.atlassian.net/browse/METRO-137

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Tested on local by creating a dlq topic, and checking its config. Also messages were purged once garbage collection happened.

# Is it a breaking change?
No

## Screenshots:
<img width="1313" alt="Screenshot 2022-09-13 at 1 20 31 PM" src="https://user-images.githubusercontent.com/104060154/189842937-6e497ced-8c40-4c07-87f0-8a0929883408.png">

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works (if applicable)
- [x] I have added integration tests for the new feature (if applicable)
- [x] I have manually tested my code to the best of my abilities.
