### PR TITLE
Reuse connection to push messages 

### DIFF
--- a/internal/stream/processor.go
+++ b/internal/stream/processor.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/razorpay/metro/pkg/httpclient"
+
 	"github.com/opentracing/opentracing-go"
 	"github.com/panjf2000/ants/v2"
 	"github.com/razorpay/metro/internal/subscription"
@@ -119,7 +121,7 @@ func (pr *processor) pushMessage(ctx context.Context, message *metrov1.ReceivedM
 
 	logFields["endpoint"] = subModel.GetRedactedPushEndpoint()
 	logger.Ctx(ctx).Infow("worker: posting messages to subscription url", "logFields", logFields)
-	resp, err := pr.httpClient.Do(req)
+	resp, err := httpclient.SendRequest(pr.httpClient, req)
 
 	// log metrics
 	workerPushEndpointCallsCount.WithLabelValues(env, subModel.Topic, subModel.Name, subModel.GetRedactedPushEndpoint(), pr.subID).Inc()

--- a/pkg/httpclient/httpclient.go
+++ b/pkg/httpclient/httpclient.go
@@ -39,3 +39,14 @@ func NewClient(config *Config) *http.Client {
 
 	return &http.Client{Transport: tr}
 }
+
+func SendRequest(client *http.Client, req *http.Request) (*http.Response, error) {
+	resp, err := client.Do(req)
+
+	// Close the body to reuse the connection
+	if err == nil {
+		defer resp.Body.Close()
+	}
+
+	return resp, err
+}

--- a/pkg/httpclient/httpclient.go
+++ b/pkg/httpclient/httpclient.go
@@ -40,6 +40,7 @@ func NewClient(config *Config) *http.Client {
 	return &http.Client{Transport: tr}
 }
 
+// SendRequest sends the request and close the response body
 func SendRequest(client *http.Client, req *http.Request) (*http.Response, error) {
 	resp, err := client.Do(req)
 

--- a/pkg/httpclient/httpclient_test.go
+++ b/pkg/httpclient/httpclient_test.go
@@ -1,4 +1,3 @@
-//go:build unit
 // +build unit
 
 package httpclient
@@ -61,6 +60,6 @@ func Test_SendRequest(t *testing.T) {
 		SendRequest(client, req)
 	}
 
-	// Only one connection should be created
+	// One connection should be created
 	assert.Equal(t, 1, connectionsCreated)
 }

--- a/pkg/httpclient/httpclient_test.go
+++ b/pkg/httpclient/httpclient_test.go
@@ -9,8 +9,12 @@ import (
 	"net/http/httptrace"
 	"testing"
 
+	"github.com/razorpay/metro/tests/pushserver"
 	"github.com/stretchr/testify/assert"
 )
+
+var ps *pushserver.PushServer
+var chanMap = map[string]chan pushserver.PushMessage{}
 
 func Test_NewClient(t *testing.T) {
 	assert.Nil(t, NewClient(nil))
@@ -28,6 +32,9 @@ func Test_NewClient(t *testing.T) {
 }
 
 func Test_SendRequest(t *testing.T) {
+	ps = pushserver.StartServer(context.TODO(), chanMap)
+	defer ps.StopServer()
+
 	connectionsCreated := 0
 	clientTrace := &httptrace.ClientTrace{
 		GotConn: func(info httptrace.GotConnInfo) {
@@ -49,8 +56,8 @@ func Test_SendRequest(t *testing.T) {
 		TLSHandshakeTimeoutMS:   2000,
 	})
 
-	for i := 0; i < 5; i++ {
-		req, _ := http.NewRequestWithContext(traceCtx, http.MethodGet, "http://localhost:8090/headers", nil)
+	for i := 0; i < 10; i++ {
+		req, _ := http.NewRequestWithContext(traceCtx, http.MethodGet, "http://localhost:8077/push", nil)
 		SendRequest(client, req)
 	}
 

--- a/pkg/httpclient/httpclient_test.go
+++ b/pkg/httpclient/httpclient_test.go
@@ -1,8 +1,12 @@
+//go:build unit
 // +build unit
 
 package httpclient
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptrace"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -21,4 +25,35 @@ func Test_NewClient(t *testing.T) {
 		ResponseHeaderTimeoutMS: 25000,
 		TLSHandshakeTimeoutMS:   2000,
 	}))
+}
+
+func Test_SendRequest(t *testing.T) {
+	connectionsCreated := 0
+	clientTrace := &httptrace.ClientTrace{
+		GotConn: func(info httptrace.GotConnInfo) {
+			if !info.Reused {
+				connectionsCreated += 1
+			}
+		},
+	}
+
+	traceCtx := httptrace.WithClientTrace(context.Background(), clientTrace)
+	client := NewClient(&Config{
+		ConnectTimeoutMS:        10000,
+		ConnKeepAliveMS:         100,
+		ExpectContinueTimeoutMS: 100,
+		IdleConnTimeoutMS:       60000,
+		MaxAllIdleConns:         1000,
+		MaxHostIdleConns:        1000,
+		ResponseHeaderTimeoutMS: 25000,
+		TLSHandshakeTimeoutMS:   2000,
+	})
+
+	for i := 0; i < 5; i++ {
+		req, _ := http.NewRequestWithContext(traceCtx, http.MethodGet, "http://localhost:8090/headers", nil)
+		SendRequest(client, req)
+	}
+
+	// Only one connection should be created
+	assert.Equal(t, 1, connectionsCreated)
 }

--- a/tests/pushserver/server.go
+++ b/tests/pushserver/server.go
@@ -99,6 +99,8 @@ func (ps *PushServer) health(w http.ResponseWriter, req *http.Request) {
 }
 
 func (ps *PushServer) pushHandler(w http.ResponseWriter, req *http.Request) {
+	w.Header().Set("Connection", "keep-alive")
+
 	var pushData PushBody
 	now := time.Now().UnixNano()
 	decoder := json.NewDecoder(req.Body)


### PR DESCRIPTION
# Description

1. Http client uses transport as round-tripper. By default connection re-use is already enabled at transport.This might create many open connections which can restricted by MaxIdleConections configuration.We are restricting the  maximum idle connection as 1000 on production.

2. HTTP client Transport may not reuse HTTP/1.x "keep-alive" TCP connections if the Body is not read to completion and closed. We are not closing the response body in our codebase. Have raised [PR](https://github.com/razorpay/metro/pull/427) to do to the same. Verified the connection reuse by manual testing and unit testing

3. We have to also add Connection => "keep-alive" as a header in the push endpoint response.  Connections are not reusing without this header while testing

4. Refer [this](https://github.com/golang/go/blob/master/src/net/http/httptrace/trace.go#L87) to know more about how connection creation is tested in local testing 


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Unit testing 
- [ ] Manual testing 

# Is it a breaking change?

How do we intend to rollback or handle backward compatibility in case something breaks?
Can this change be tested effectively via canary?

## Screenshots:

Include a screenshot of the changes, if applicable.

# Checklist Exception

- [ ] My change doesn't require the below checklist to be updated.
Please add a description on why it is not applicable.

# Checklist:

- [ x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added integration tests for the new feature (if applicable)
- [x] I have manually tested my code to the best of my abilities.
