### PR TITLE
updates go-plantuml dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ deps: buf-deps
 	@go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2@v2.5.0
 	@go install github.com/rakyll/statik@v0.1.7
 	@go install golang.org/x/lint/golint@latest
-	@go install github.com/bykof/go-plantuml@v1.0.0
+	@go install github.com/bykof/go-plantuml@v1.1.7
 	@go install github.com/golang/mock/mockgen@v1.6.0
 
 buf-deps:


### PR DESCRIPTION
# Description

v1.0.0 of plantuml depends on [sys](url) `golang.org/x/sys v0.0.0-20200121082415-34d275377bf9` which breaks while building the dependency on go1.19 on M1 (ARM64) arch. 

sys packages are not supposed to be backwards compatible. latest version of the lib solves the issue.


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

# Is it a breaking change? No

How do we intend to rollback or handle backward compatibility in case something breaks?
Can this change be tested effectively via canary?

## Screenshots:

Include a screenshot of the changes, if applicable.

# Checklist Exception

- [X] My change doesn't require the below checklist to be updated.
Please add a description on why it is not applicable.

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works (if applicable)
- [ ] I have added integration tests for the new feature (if applicable)
- [ ] I have manually tested my code to the best of my abilities.
